### PR TITLE
Add Github Actions workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/1-feature-request.yml
@@ -1,0 +1,57 @@
+name: ✨ Feature Request
+description: Suggest an idea for this project
+title: "[Feature]: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Feature Request
+        Please provide detailed information about the feature you'd like to see added.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Is your feature request related to a problem?
+      description: A clear and concise description of what the problem is.
+      placeholder: I'm always frustrated when [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+      placeholder: It would be great if [...]
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+      placeholder: I thought about doing [...] but [...]
+    validations:
+      required: false
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Add any other context, screenshots, or mockups about the feature request here.
+      placeholder: More details that might help understand the request...
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Before submitting
+      description: By submitting this feature request, you confirm that...
+      options:
+        - label: I have searched existing issues to ensure this feature hasn't already been requested
+          required: true
+        - label: This is a single feature (not multiple features in one request)
+          required: true 

--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -1,0 +1,86 @@
+name: 🐛 Bug Report
+description: Report a bug or issue
+title: "[Bug]: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ### Bug Report
+        Please provide detailed information about the bug to help us resolve it quickly.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Bug Description
+      description: A clear and concise description of what the bug is.
+      placeholder: Tell us what happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: List the steps to reproduce the behavior
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: A clear and concise description of what you expected to happen.
+      placeholder: Tell us what should have happened...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened instead?
+      placeholder: Tell us what happened instead...
+    validations:
+      required: true
+
+  - type: input
+    id: wp_version
+    attributes:
+      label: WordPress Version
+      description: What version of WordPress are you running?
+      placeholder: "6.4.2"
+    validations:
+      required: true
+
+  - type: input
+    id: wc_version
+    attributes:
+      label: WooCommerce Version
+      description: What version of WooCommerce are you running?
+      placeholder: "8.5.1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: If applicable, add screenshots to help explain your problem
+      placeholder: Drag and drop images here...
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here (theme, other plugins, server environment, etc.)
+      placeholder: Any other relevant information...
+    validations:
+      required: false 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,30 @@
+* Fix #
+
+### Description
+
+Explain why these changes are important - what is the problem, and how this PR fixes it.
+
+### Changes in this PR
+
+-
+-
+-
+
+### Test Instructions
+
+Add the specific steps to reproduce the problem, and confirm the correction. Ideally, these steps should allow anyone to reproduce the problem and the correction as a lambda user would experience it.
+
+1. Checkout this branch locally.
+2. 
+3. 
+
+### Things to check
+
+Here are some things we should check every time we create a PR. Depending on the changes made, some things may not apply to the current PR.
+
+This list is intended for the author, but reviewers should also perform these checks.
+
+- [ ] Are all texts internationalized?
+- [ ] Has a cache been added?
+- [ ] Are the hooks/filters called only when necessary?
+- [ ] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications?

--- a/.github/workflows/asset-release-workflow.yml
+++ b/.github/workflows/asset-release-workflow.yml
@@ -1,0 +1,58 @@
+name: Asset Release Workflow
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 1. Checkout the repository code
+      - name: 👉 Checkout code
+        uses: actions/checkout@v3
+
+      # 2. Install necessary packages: zip and rsync
+      - name: 🗄 Install zip and rsync
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y zip rsync
+
+      # 3. Create the required directory structure
+      - name: 📂 Create required directory structure
+        run: |
+          mkdir customs-fees-for-woocommerce
+          rsync -av \
+            --exclude="customs-fees-for-woocommerce" \
+            --exclude="assets" \
+            --exclude="src" \
+            --exclude=".github" \
+            --exclude=".gitignore" \
+            --exclude="*.md" \
+            --exclude=".node_modules" \
+            --exclude="package.json" \
+            --exclude="package-lock.json" \
+            --exclude="prompts" \
+            --exclude="bin" \
+            --exclude="sales.md" \
+            ./* customs-fees-for-woocommerce/
+
+      # 4. Zip the project
+      - name: 📦 Zip the project
+        run: zip -r customs-fees-for-woocommerce.zip customs-fees-for-woocommerce/
+
+      # 5. Upload the zipped project as a release asset
+      - name: 📤 Upload Release Asset
+        uses: actions/upload-release-asset@v1.0.2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./customs-fees-for-woocommerce.zip
+          asset_name: customs-fees-for-woocommerce.zip
+          asset_content_type: application/zip
+
+      # 6. All good
+      - name: 🎉 All good
+        run: echo "All good!"


### PR DESCRIPTION
Adding basic Github workflow:

* Issue templates when creating Github issues
* Asset release workflow when releasing a new version (Strips out unwanted build files and generates a clean zip file)
* Creates a template to be completed for future PRs