### PR TITLE
chore: exclude AI instruction files from archive

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,9 @@
             "composer.lock",
             "node_modules",
             "customs-fees-for-woocommerce.zip",
-            ".*"
+            ".*",
+            "AGENTS.md",
+            "CLAUDE.md"
         ]
     },
     "require-dev": {

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,0 +1,4 @@
+{
+  "status": "passed",
+  "failedTests": []
+}


### PR DESCRIPTION
Excludes `AGENTS.md` and/or `CLAUDE.md` from the Composer archive zip to keep the distributed plugin package clean. These files are for AI coding agents and are not needed by end users.