### PR TITLE
fix: add Woo header for WooCommerce.com deployment

### DIFF
--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -16,6 +16,7 @@
  * Requires PHP:      7.4
  * WC requires at least: 10.4
  * WC tested up to:   10.6
+ * Woo: 18734005702334:78cd9350327fbb9496bc3fbfd7335b53
  *
  * @package CustomsFeesForWooCommerce
  */


### PR DESCRIPTION
## Summary

- Adds the missing `Woo:` header to the main plugin file, required by woorelease and the Product Build Server (PBS) for WooCommerce.com marketplace deployment
- Without this header, `woorelease release` fails with: `'Woo' headers are missing in the plugin file which are required`

### How the values were determined

- **Product ID** (`18734005702334`): From the WooCommerce.com product edit page
- **Hash** (`78cd9350327fbb9496bc3fbfd7335b53`): `md5("customs-fees-for-woocommerce.zip")` — per PBS source code (`Automattic/wccom-product-build-server`)