### PR TITLE
[CUSFEES-11] Tweak - WooCommerce 10.7 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Customs Fees for WooCommerce Changelog ***
 
+2026-xx-xx - version 1.1.7
+* Tweak - WooCommerce 10.7 Compatibility.
+
 2026-03-31 - version 1.1.6
 * Tweak - WooCommerce 10.6 Compatibility.
 

--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -14,8 +14,8 @@
  * Requires at least: 6.8
  * Tested up to:      6.9
  * Requires PHP:      7.4
- * WC requires at least: 10.4
- * WC tested up to:   10.6
+ * WC requires at least: 10.5
+ * WC tested up to:   10.7
  * Woo: 18734005702334:78cd9350327fbb9496bc3fbfd7335b53
  *
  * @package CustomsFeesForWooCommerce

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 6.8
 Tested up to: 6.9
 Requires PHP: 7.4
 Requires Plugins: woocommerce
-WC requires at least: 10.4
-WC tested up to: 10.6
+WC requires at least: 10.5
+WC tested up to: 10.7
 Stable tag: 1.1.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -191,6 +191,9 @@ Yes, through:
 8. Email with customs fee information
 
 == Changelog ==
+
+= 1.1.7 - 2026-xx-xx =
+* Tweak - WooCommerce 10.7 Compatibility.
 
 = 1.1.6 - 2026-xx-xx =
 * Tweak - WooCommerce 10.6 Compatibility.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Declares compatibility with WooCommerce 10.7 and bumps the minimum required WooCommerce version to 10.5.

Closes #CUSFEES-11 .

### How to test the changes in this Pull Request:

1. Install the plugin alongside WooCommerce 10.7.
2. Verify the plugin activates without errors.
3. Confirm core functionality works correctly with no errors logged.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - WooCommerce 10.7 Compatibility.