### PR TITLE
[CUSFEES-12] Fix: Per-rule valuation and compound bases for CA/AU/NZ presets

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -220,6 +220,9 @@
 	width: 100%;
 }
 
+/* Unified 5px vertical gap between stacked form controls in a rule row.
+   (Field-to-help/required text gap is the tighter 2px via the help/required
+   element's own margin-top below.) */
 .cfwc-rule-row .cfwc-rule-field--label,
 .cfwc-rule-row .cfwc-rule-field--match-type,
 .cfwc-rule-row .cfwc-rule-field--category {
@@ -232,16 +235,6 @@
 
 .cfwc-rule-row .cfwc-rule-field--rate {
 	width: 80px;
-}
-
-.cfwc-rule-row .cfwc-field-spacer {
-	display: none;
-	width: 100%;
-	height: 5px;
-}
-
-.cfwc-rule-row .cfwc-field-spacer.is-visible {
-	display: block;
 }
 
 .cfwc-rule-row .cfwc-field-help {

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -664,3 +664,555 @@ span[aria-labelledby="select2-_cfwc_country_of_origin-container"] {
 	font-size: 13px;
 	}
 }
+
+/* ==========================================================================
+	Rules table column widths
+	========================================================================== */
+
+.cfwc-rules-table .cfwc-col-label,
+.cfwc-rules-table .cfwc-col-countries,
+.cfwc-rules-table .cfwc-col-products {
+	width: 15%;
+}
+
+.cfwc-rules-table .cfwc-col-type,
+.cfwc-rules-table .cfwc-col-valuation,
+.cfwc-rules-table .cfwc-col-depends,
+.cfwc-rules-table .cfwc-col-stacking {
+	width: 10%;
+}
+
+.cfwc-rules-table .cfwc-col-rate {
+	width: 7%;
+}
+
+.cfwc-rules-table .cfwc-col-actions {
+	width: 8%;
+}
+
+/* ==========================================================================
+	Rules table inline content
+	========================================================================== */
+
+.cfwc-rules-table .cfwc-priority-meta {
+	color: #666;
+	font-size: 11px;
+}
+
+.cfwc-rules-table .cfwc-priority-meta .dashicons {
+	font-size: 14px;
+	vertical-align: middle;
+	cursor: help;
+}
+
+.cfwc-rules-table .cfwc-criteria-icon {
+	font-size: 14px;
+}
+
+.cfwc-rules-table .cfwc-empty-cell {
+	color: #999;
+	font-size: 11px;
+}
+
+/* ==========================================================================
+	Badges
+	========================================================================== */
+
+.cfwc-rule-badge {
+	display: inline-block;
+	padding: 3px 8px;
+	color: #fff;
+	border-radius: 3px;
+	font-size: 11px;
+	font-weight: 600;
+	line-height: 1;
+}
+
+.cfwc-rule-badge--valuation {
+	background: #2271b1;
+}
+
+.cfwc-rule-badge--dependency {
+	background: #8261a1;
+}
+
+.cfwc-rule-badge--stacking-add {
+	background: #46b450;
+}
+
+.cfwc-rule-badge--stacking-override {
+	background: #f0ad4e;
+}
+
+.cfwc-rule-badge--stacking-exclusive {
+	background: #dc3232;
+}
+
+/* ==========================================================================
+	Rule row form fields (used by rules table edit/add rows in admin.js)
+	========================================================================== */
+
+.cfwc-rule-row .cfwc-rule-field {
+	width: 100%;
+}
+
+.cfwc-rule-row .cfwc-rule-field--label,
+.cfwc-rule-row .cfwc-rule-field--match-type,
+.cfwc-rule-row .cfwc-rule-field--category {
+	margin-bottom: 5px;
+}
+
+.cfwc-rule-row .cfwc-rule-field--country {
+	width: 47%;
+}
+
+.cfwc-rule-row .cfwc-rule-field--rate {
+	width: 80px;
+}
+
+.cfwc-rule-row .cfwc-country-spacer {
+	display: inline-block;
+	width: 10px;
+}
+
+.cfwc-rule-row .cfwc-field-spacer {
+	display: none;
+	height: 5px;
+	width: 100%;
+}
+
+.cfwc-rule-row .cfwc-field-spacer.is-visible {
+	display: block;
+}
+
+.cfwc-rule-row .cfwc-field-help {
+	font-size: 11px;
+	color: #666;
+	margin-top: 2px;
+	display: block;
+}
+
+.cfwc-rule-row .cfwc-field-help--inline {
+	display: inline-block;
+}
+
+.cfwc-rule-row .cfwc-field-required {
+	display: block;
+	font-size: 11px;
+	color: #999;
+	margin-top: 2px;
+}
+
+.cfwc-rule-row .cfwc-stacking-help span {
+	display: none;
+}
+
+.cfwc-rule-row .is-hidden {
+	display: none;
+}
+
+.cfwc-rule-row .cfwc-stacking-help span.is-visible {
+	display: inline;
+}
+
+/* ==========================================================================
+	Delete confirmation warning
+	========================================================================== */
+
+.cfwc-delete-warning {
+	color: #d63638;
+	margin-left: 10px;
+	font-weight: 600;
+}
+
+.button.confirm-delete,
+.button.confirm-replace {
+	background: #d63638;
+	color: #fff;
+	border-color: #d63638;
+}
+
+.button.confirm-delete:hover,
+.button.confirm-replace:hover {
+	background: #b32d2e;
+	color: #fff;
+}
+
+/* ==========================================================================
+	Edit-screen meta box helpers (class-cfwc-admin.php)
+	========================================================================== */
+
+.cfwc-fees-breakdown-list {
+	margin: 10px 0;
+	padding-left: 20px;
+}
+
+.cfwc-fees-breakdown-list li {
+	margin: 5px 0;
+}
+
+.cfwc-fees-divider {
+	margin: 10px 0;
+}
+
+.cfwc-section-divider {
+	margin: 15px 0;
+}
+
+.cfwc-product-customs-list {
+	margin: 10px 0 0 20px;
+}
+
+/* ==========================================================================
+	Product edit screen
+	========================================================================== */
+
+.cfwc-product-fields-heading {
+	margin: 10px 12px 5px;
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.cfwc-hs-code-help {
+	margin-left: 154px;
+	margin-top: -10px;
+	margin-bottom: 10px;
+	font-size: 12px;
+	color: #666;
+}
+
+/* ==========================================================================
+	Order item meta (admin order screen)
+	========================================================================== */
+
+.cfwc-order-item-meta {
+	margin-top: 0.5em;
+}
+
+/* ==========================================================================
+	Onboarding notice
+	========================================================================== */
+
+.cfwc-dismiss-notice {
+	margin-left: 15px;
+}
+
+/* ==========================================================================
+	Settings: default origin select
+	========================================================================== */
+
+#cfwc_default_origin_select {
+	width: 350px;
+	max-width: 50%;
+}
+
+/* ==========================================================================
+	Settings: rules section header / preset / notices
+	========================================================================== */
+
+.cfwc-default-origin-help {
+	display: block;
+	margin: 2px 0 8px 24px;
+	color: #666;
+}
+
+.cfwc-help-link-under {
+	margin-top: 10px;
+}
+
+.cfwc-help-link-under .dashicons-info {
+	color: #2271b1;
+}
+
+.cfwc-rules-divider {
+	margin: 40px 0 30px 0;
+	border-top: 1px solid #c3c4c7;
+}
+
+.cfwc-notices-container {
+	margin-bottom: 20px;
+}
+
+.cfwc-notices-container > .notice {
+	margin-bottom: 10px;
+}
+
+.cfwc-rules-header-info {
+	flex: 1;
+}
+
+.cfwc-rules-header-title {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-bottom: 10px;
+}
+
+.cfwc-rules-header-title h3,
+.cfwc-rules-header-info p {
+	margin: 0;
+}
+
+.cfwc-rules-header-actions {
+	align-self: flex-start;
+}
+
+#cfwc-preset-select {
+	width: 280px;
+	max-width: 100%;
+}
+
+/* ==========================================================================
+	WooCommerce-style modal (moved from rules-section.php inline <style>)
+	========================================================================== */
+
+.cfwc-modal {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 160000;
+}
+
+.cfwc-modal-backdrop {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(0, 0, 0, 0.6);
+	z-index: 159990;
+}
+
+.cfwc-modal-content {
+	position: absolute;
+	top: 50%;
+	left: 50%;
+	transform: translate(-50%, -50%);
+	width: 90%;
+	max-width: 600px;
+	max-height: 90vh;
+	background: #fff;
+	border-radius: 4px;
+	box-shadow: 0 3px 30px rgba(0, 0, 0, 0.2);
+	z-index: 160000;
+	display: flex;
+	flex-direction: column;
+}
+
+.cfwc-modal-header {
+	padding: 20px;
+	border-bottom: 1px solid #e0e0e0;
+	display: flex;
+	justify-content: space-between;
+	align-items: center;
+}
+
+.cfwc-modal-header h2 {
+	margin: 0;
+	font-size: 18px;
+	font-weight: 600;
+	color: #333;
+}
+
+.cfwc-modal-close {
+	background: none;
+	border: none;
+	cursor: pointer;
+	padding: 0;
+	color: #999;
+	font-size: 20px;
+}
+
+.cfwc-modal-close:hover {
+	color: #333;
+}
+
+.cfwc-modal-body {
+	padding: 20px;
+	overflow-y: auto;
+	flex: 1;
+}
+
+.cfwc-modal-footer {
+	padding: 20px;
+	border-top: 1px solid #e0e0e0;
+	text-align: right;
+}
+
+.cfwc-help-section {
+	margin-bottom: 30px;
+}
+
+.cfwc-help-section:last-child {
+	margin-bottom: 0;
+}
+
+.cfwc-help-section h3 {
+	margin: 0 0 15px 0;
+	font-size: 14px;
+	font-weight: 600;
+	color: #333;
+}
+
+.cfwc-help-section h3 .dashicons {
+	font-size: 18px;
+	vertical-align: middle;
+	margin-right: 5px;
+	color: #2271b1;
+}
+
+.cfwc-help-section h3 .dashicons-lightbulb {
+	color: #f0ad4e;
+}
+
+.cfwc-help-section ol,
+.cfwc-help-section ul {
+	margin: 0;
+	padding-left: 25px;
+	font-size: 14px;
+	line-height: 1.8;
+	color: #555;
+}
+
+.cfwc-help-section li {
+	margin-bottom: 8px;
+}
+
+.cfwc-stacking-modes {
+	margin-top: 10px;
+}
+
+.cfwc-stacking-mode {
+	margin-bottom: 10px;
+	display: flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.cfwc-help-section .cfwc-badge {
+	display: inline-block;
+	padding: 4px 10px;
+	border-radius: 3px;
+	font-size: 12px;
+	font-weight: 600;
+	color: #fff;
+	min-width: 70px;
+	text-align: center;
+}
+
+.cfwc-help-section .cfwc-badge-stack {
+	background: #46b450;
+}
+
+.cfwc-help-section .cfwc-badge-override {
+	background: #f0ad4e;
+}
+
+.cfwc-help-section .cfwc-badge-exclusive {
+	background: #dc3232;
+}
+
+@media screen and (max-width: 768px) {
+	.cfwc-modal-content {
+		width: 100%;
+		height: 100%;
+		max-width: none;
+		max-height: none;
+		border-radius: 0;
+		transform: none;
+		position: fixed;
+		top: 0;
+		left: 0;
+	}
+
+	#cfwc_default_origin_select {
+		width: 100% !important;
+		margin-left: 0 !important;
+		margin-top: 10px;
+	}
+}
+
+/* ==========================================================================
+	WordPress/Gutenberg snackbar repositioning (moved from admin.js inline <style>)
+	========================================================================== */
+
+body .components-snackbar-list,
+body .components-snackbar-list__notices-container {
+	position: fixed !important;
+	right: 20px !important;
+	left: auto !important;
+	bottom: 30px !important;
+	width: auto !important;
+	max-width: 400px !important;
+	z-index: 100001 !important;
+}
+
+body .components-snackbar {
+	margin-right: 0 !important;
+	margin-left: auto !important;
+}
+
+body.woocommerce_page_wc-settings .components-snackbar-list {
+	right: 20px !important;
+	left: auto !important;
+}
+
+@media (max-width: 782px) {
+	body .components-snackbar-list {
+		right: 10px !important;
+		bottom: 80px !important;
+		max-width: calc(100vw - 20px) !important;
+	}
+}
+
+.woocommerce .submit {
+	position: relative !important;
+	z-index: 99999 !important;
+}
+
+body.woocommerce_page_wc-settings {
+	padding-bottom: 100px !important;
+}
+
+/* ==========================================================================
+	Fallback admin notice (used by admin.js when wp.data unavailable)
+	========================================================================== */
+
+.cfwc-admin-notice-wrapper {
+	position: fixed;
+	right: 20px;
+	bottom: 30px;
+	max-width: 400px;
+	z-index: 100001;
+	background: #fff;
+	border-left: 4px solid #46b450;
+	box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
+	padding: 12px;
+}
+
+.cfwc-admin-notice-wrapper.is-error {
+	border-left-color: #dc3232;
+}
+
+.cfwc-admin-notice-wrapper.is-warning {
+	border-left-color: #ffb900;
+}
+
+.cfwc-admin-notice-wrapper .notice {
+	margin: 0;
+	border: none;
+	box-shadow: none;
+	padding: 0;
+}
+
+.cfwc-admin-notice-wrapper .notice p {
+	margin: 0;
+}
+
+.cfwc-admin-notice-wrapper .notice-dismiss {
+	position: absolute;
+	top: 0;
+	right: 0;
+}

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -222,10 +222,13 @@
 
 /* Unified 5px vertical gap between stacked form controls in a rule row.
    (Field-to-help/required text gap is the tighter 2px via the help/required
-   element's own margin-top below.) */
+   element's own margin-top below.)
+   For Select2-enhanced fields the original <select> is display:none, so the
+   gap is applied to the visible .select2-container sibling instead. */
 .cfwc-rule-row .cfwc-rule-field--label,
 .cfwc-rule-row .cfwc-rule-field--match-type,
-.cfwc-rule-row .cfwc-rule-field--category {
+.cfwc-rule-row .cfwc-rule-field--category,
+.cfwc-rule-row .cfwc-rule-field--category + .select2-container {
 	margin-bottom: 5px;
 }
 
@@ -767,14 +770,20 @@ body[class*="branch-7"] .cfwc-rules-table tbody tr {
 	height: 50px;
 }
 
+/* Single-line form controls keep a fixed 40px height. */
 body[class*="branch-7"] .cfwc-rule-editing input[type="text"],
 body[class*="branch-7"] .cfwc-rule-editing input[type="number"],
 body[class*="branch-7"] .cfwc-rule-editing select:not(.select2-hidden-accessible),
 body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single,
-body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--multiple,
 body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single,
 body[class*="branch-7"] .cfwc-preset-loader .select2-container .select2-selection--single {
 	height: 40px;
+}
+
+/* Multi-selects (Select2 chips) grow vertically with their content. */
+body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--multiple {
+	height: auto;
+	min-height: 40px;
 }
 
 body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single .select2-selection__rendered,

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -5,733 +5,89 @@
  * @since 1.0.0
  */
 
-/* Rules Table General Styles */
+/* ==========================================================================
+   Animations
+   ========================================================================== */
+
+@keyframes fadeIn {
+	from { opacity: 0; }
+	to   { opacity: 1; }
+}
+
+/* ==========================================================================
+   Rules section + table layout
+   ========================================================================== */
+
+.cfwc-rules-section {
+	max-width: 100%;
+	overflow: visible;
+}
+
+.cfwc-rules-table-wrapper {
+	position: relative;
+	max-width: 100%;
+	margin: 0 0 10px;
+	overflow-x: auto;
+}
+
 .cfwc-rules-table {
 	width: 100%;
+	min-width: 700px;
 	margin-top: 20px;
+	table-layout: fixed;
+	border-collapse: collapse;
 }
 
 .cfwc-rules-table th {
 	text-align: left;
 }
 
-.cfwc-rules-table .button-small {
-	margin: 0 5px;
-}
-
-/* Template Selector */
-.cfwc-template-selector {
-	margin: 20px 0;
-	padding: 15px;
-	background: #f7f7f7;
-	border-radius: 4px;
-}
-
-.cfwc-template-selector select {
-	min-width: 300px;
-}
-
-/* Preset Loader Section */
-.cfwc-preset-loader {
-	/* Removed background, border, and padding for cleaner look */
-	margin-top: 40px;
-	margin-bottom: 30px;
-}
-
-.cfwc-preset-loader h3 {
-	margin-top: 0;
-	margin-bottom: 15px;
-	font-size: 1.3em;
-}
-
-.cfwc-preset-loader p {
-	margin-bottom: 20px;
-}
-
-/* Admin Notice Styles - Fixed positioning and width */
-.cfwc-admin-notice {
-	position: relative;
-	margin: 5px 0 15px;
-	padding: 12px 40px 12px 12px;
-	border: 1px solid transparent;
-	border-left-width: 4px;
-	box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
-	background: #fff;
-	display: block;
-}
-
-.cfwc-admin-notice.error {
-	border-left-color: #dc3232;
-}
-
-.cfwc-admin-notice.warning {
-	border-left-color: #ffb900;
-}
-
-.cfwc-admin-notice.info {
-	border-left-color: #00a0d2;
-}
-
-.cfwc-admin-notice.success {
-	border-left-color: #46b450;
-}
-
-.cfwc-admin-notice .notice-message {
-	margin: 0;
-	padding: 0;
-}
-
-.cfwc-admin-notice button.notice-dismiss {
-	position: absolute;
-	top: 0;
-	right: 1px;
-	border: none;
-	margin: 0;
-	padding: 9px;
-	background: none;
-	color: #b4b9be;
-	cursor: pointer;
-	width: 36px;
-	height: 36px;
-	text-align: center;
-}
-
-.cfwc-admin-notice button.notice-dismiss:before {
-	content: "\f153";
-	font: normal 16px/20px dashicons;
-	speak: never;
-	display: block;
-	width: 20px;
-	height: 20px;
-	text-align: center;
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-}
-
-.cfwc-admin-notice button.notice-dismiss:hover {
-	color: #c00;
-}
-
-.cfwc-admin-notice button.notice-dismiss:focus {
-	outline: none;
-	box-shadow: 0 0 0 1px #5b9dd9, 0 0 2px 1px rgba(30, 140, 190, 0.8);
-}
-
-/* Delete All Button Styles */
-/* Delete all button styles moved to line 495 */
-
-/* Delete Button Hover State */
-.cfwc-delete-rule:hover {
-	color: #d63638;
-	border-color: #d63638;
-}
-
-/* Table Row Fade Effect */
-.cfwc-rules-table tbody tr {
-	transition: opacity 0.3s;
-}
-
-/* Table Styling Improvements */
-.cfwc-rules-table table {
-	table-layout: fixed;
-}
-
-.cfwc-rules-table th,
-.cfwc-rules-table td {
-	padding: 10px;
-	vertical-align: middle;
-}
-
-/* Editing Row Styles */
-.cfwc-rule-editing {
-	background: #f0f8ff;
-	border: 1px solid #0073aa;
-}
-
-.cfwc-rule-editing td {
-	padding: 10px 5px;
-}
-
-.cfwc-rule-field {
-	width: 100%;
-	max-width: 100%;
-}
-
-/* WooCommerce Native Select2 Styling - Match WooCommerce exactly */
-.cfwc-rule-editing .wc-enhanced-select,
-.cfwc-country-select,
-.cfwc-origin-select {
-	min-width: 150px !important;
-	max-width: 100% !important;
-	width: 100% !important;
-}
-
-/* Product Edit Page - Country of Origin Select2 */
-#_cfwc_country_of_origin {
-	width: 250px;
-}
-
-/* Select2 Container for our field specifically */
-span[aria-labelledby="select2-_cfwc_country_of_origin-container"] {
-	width: 250px !important;
-}
-
-/* Select2 Container - alternative selector */
-#_cfwc_country_of_origin + .select2-container {
-	width: 250px !important;
-}
-
-/* The select2 dropdown for Country of Origin specifically */
-#select2-_cfwc_country_of_origin-results {
-	max-width: 250px !important;
-}
-
-/*
- * Select2 height normalization for WP 7.0+.
- */
-body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single {
-	height: 40px;
-}
-
-body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single .select2-selection__rendered {
-	line-height: 38px;
-}
-
-body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single .select2-selection__arrow {
-	height: 38px;
-}
-
-body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--multiple {
-	min-height: 40px;
-}
-
-body[class*="branch-7"] .cfwc-rule-editing input[type="text"],
-body[class*="branch-7"] .cfwc-rule-editing input[type="number"],
-body[class*="branch-7"] .cfwc-rule-editing select:not(.select2-hidden-accessible) {
-	min-height: 40px;
-}
-
-/* From / To country selects stack vertically — add a 5px gap to the visible Select2 widget after the From field. */
-.cfwc-country-select[data-field="from_country"] + .select2-container {
-	margin-bottom: 5px;
-}
-
-/* WooCommerce Snackbar Container - Align with Save button */
-.components-snackbar-list {
-	position: fixed;
-	bottom: 20px;
-	left: 180px; /* Align with Save changes button */
-	right: 20px;
-	display: flex;
-	justify-content: flex-start; /* Align to left like save button */
-	gap: 15px; /* Space between multiple notifications */
-	z-index: 100001; /* Above WP admin elements */
-	pointer-events: none; /* Allow clicking through container */
-}
-
-/* Adjust for collapsed admin menu */
-.folded .components-snackbar-list {
-	left: 56px; /* Collapsed menu width + padding */
-}
-
-/* Mobile responsive */
-@media screen and (max-width: 782px) {
-	.components-snackbar-list {
-	left: 10px; /* Small padding on mobile */
-	right: 10px;
-	}
-}
-
-/* Auto-collapsed menu (960px-782px) */
-@media screen and (max-width: 960px) and (min-width: 783px) {
-	.auto-fold .components-snackbar-list {
-	left: 56px; /* Auto-collapsed menu width + padding */
-	}
-}
-
-.components-snackbar-list .components-snackbar {
-	pointer-events: auto; /* But allow clicking snackbar itself */
-	max-width: 600px; /* Limit width for readability */
-	margin: 0; /* Reset any default margins */
-}
-
-/* Ensure snackbar doesn't interfere with save button */
-.woocommerce-save-button {
-	position: relative;
-	z-index: 10;
-}
-
-/* Preset Select Styling */
-#cfwc-preset-select {
-	min-width: 200px;
-}
-
-/* Rules Table - Stable Layout Solution */
-.cfwc-rules-section {
-	max-width: 100%;
-	overflow: visible;
-}
-
-/* Table wrapper */
-.cfwc-rules-table-wrapper {
-	max-width: 100%;
-	overflow-x: auto;
-	margin: 0 0 10px 0;
-	/* Prevent viewport overflow */
-	position: relative;
-}
-
-/* Main table styling */
-.cfwc-rules-table {
-	width: 100%;
-	table-layout: fixed; /* Critical: prevents column width changes */
-	border-collapse: collapse;
-	min-width: 700px; /* Minimum for readability */
-}
-
-/* Fixed column widths - same for view and edit modes */
 .cfwc-rules-table th,
 .cfwc-rules-table td {
 	padding: 8px;
 	vertical-align: middle;
 }
 
+.cfwc-rules-table .button-small {
+	margin: 0 5px;
+}
+
+/* Layout-shift prevention: fixed row height in view mode (edit row sets height:auto). */
+.cfwc-rules-table tbody tr {
+	height: 38px;
+	transition: opacity 0.3s;
+}
+
+/* Legacy 6-column layout (nth-child) — kept for backwards compatibility. */
 .cfwc-rules-table th:nth-child(1),
-.cfwc-rules-table td:nth-child(1) {
-	width: 18%; /* Label */
-	min-width: 120px;
-}
-
+.cfwc-rules-table td:nth-child(1),
 .cfwc-rules-table th:nth-child(2),
-.cfwc-rules-table td:nth-child(2) {
-	width: 18%; /* Destination */
-	min-width: 120px;
-}
-
+.cfwc-rules-table td:nth-child(2),
 .cfwc-rules-table th:nth-child(3),
 .cfwc-rules-table td:nth-child(3) {
-	width: 18%; /* Origin */
+	width: 18%;
 	min-width: 120px;
 }
 
 .cfwc-rules-table th:nth-child(4),
 .cfwc-rules-table td:nth-child(4) {
-	width: 12%; /* Type */
+	width: 12%;
 	min-width: 90px;
 }
 
 .cfwc-rules-table th:nth-child(5),
 .cfwc-rules-table td:nth-child(5) {
-	width: 14%; /* Rate/Amount */
+	width: 14%;
 	min-width: 100px;
 }
 
 .cfwc-rules-table th:nth-child(6),
 .cfwc-rules-table td:nth-child(6) {
-	width: 20%; /* Actions */
+	width: 20%;
 	min-width: 160px;
 }
 
-/* Normal row styling */
-.cfwc-rule-row td {
-	background: #fff;
-	transition: background-color 0.2s;
-}
-
-.cfwc-rule-row:hover td {
-	background: #f8f9fa;
-}
-
-/* Edit row styling - prevent overflow */
-.cfwc-rule-editing {
-	background: #f0f6fc !important;
-}
-
-.cfwc-rule-editing td {
-	padding: 6px 4px;
-	position: relative;
-	overflow: visible; /* Allow dropdowns to show */
-}
-
-/* Input fields - contained within cells */
-.cfwc-rule-editing input[type="text"],
-.cfwc-rule-editing input[type="number"] {
-	width: calc(100% - 4px);
-	max-width: 100%;
-	box-sizing: border-box;
-	padding: 4px 6px;
-	font-size: 13px;
-	border: 1px solid #8c8f94;
-	margin: 0;
-}
-
-/* Regular select elements */
-.cfwc-rule-editing select:not(.select2-hidden-accessible) {
-	width: 100%;
-	max-width: 100%;
-	box-sizing: border-box;
-	padding: 4px;
-	font-size: 13px;
-	border: 1px solid #8c8f94;
-}
-
-/* Select2 specific fixes */
-.cfwc-rule-editing .select2-container {
-	width: 100% !important;
-	max-width: 100% !important;
-	display: block !important;
-	box-sizing: border-box !important;
-}
-
-.cfwc-rule-editing .select2-container--default .select2-selection--single {
-	height: 28px;
-	line-height: 26px;
-	padding: 0 20px 0 5px;
-	font-size: 13px;
-}
-
-/* WP 7.0+ override for the rules-editing row Select2. */
-body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single {
-	height: 40px;
-	line-height: 38px;
-}
-
-body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single .select2-selection__rendered {
-	line-height: 38px;
-}
-
-body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single .select2-selection__arrow {
-	height: 38px;
-}
-
-/* Prevent Select2 dropdown from causing overflow */
-.select2-container--open .select2-dropdown {
-	min-width: 200px !important;
-	max-width: 400px !important;
-}
-
-/* Custom class for our dropdowns */
-.cfwc-select2-dropdown {
-	max-width: 400px !important;
-}
-
-/* Actions column */
-.cfwc-actions {
-	white-space: nowrap;
-}
-
-.cfwc-actions button {
-	margin: 0 2px;
-	padding: 3px 8px;
-	font-size: 12px;
-}
-
-/* Prevent layout shift when switching modes */
-.cfwc-rules-table tbody tr {
-	height: 38px; /* Fixed height to prevent jumping */
-}
-
-/* WP 7.0+ row height to accommodate 40px form fields. */
-body[class*="branch-7"] .cfwc-rules-table tbody tr {
-	height: 50px;
-}
-
-.cfwc-rule-editing {
-	height: auto; /* Allow edit row to be taller if needed */
-}
-
-/* No results row */
-.no-rules td {
-	text-align: center;
-	padding: 20px;
-	color: #646970;
-	font-style: italic;
-}
-
-/* Responsive behavior */
-@media screen and (max-width: 1024px) {
-	.cfwc-rules-table {
-	font-size: 12px;
-	}
-
-	.cfwc-rules-table th,
-	.cfwc-rules-table td {
-	padding: 6px 4px;
-	}
-
-	.cfwc-rule-editing input,
-	.cfwc-rule-editing select {
-	font-size: 12px;
-	}
-}
-
-/* Preset Description */
-#cfwc-preset-description {
-	margin-top: 10px;
-	display: none;
-}
-
-/* Rules Header Layout */
-.cfwc-rules-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: flex-start;
-	margin-top: 30px;
-	margin-bottom: 20px;
-	flex-wrap: wrap;
-	gap: 15px;
-}
-
-.cfwc-rules-header h3 {
-	margin: 0;
-	font-size: 1.3em;
-}
-
-.cfwc-rules-header p {
-	margin: 0;
-	color: #666;
-	font-size: 14px;
-}
-
-.cfwc-help-link-under {
-	color: #2271b1;
-	text-decoration: none;
-	font-size: 13px;
-	display: inline-flex;
-	align-items: center;
-}
-
-.cfwc-help-link-under:hover {
-	color: #135e96;
-	text-decoration: none;
-}
-
-.cfwc-help-link-under:hover .cfwc-help-text {
-	text-decoration: underline;
-}
-
-/* Add New Rule and Delete All Buttons when beside title */
-.cfwc-add-rule,
-.cfwc-delete-all {
-	white-space: nowrap;
-}
-
-.cfwc-add-rule:hover {
-	background: #f0f0f1;
-	border-color: #0a4b78;
-	color: #0a4b78;
-}
-
-/* Delete All button styling */
-.cfwc-delete-all {
-	color: #d63638;
-	border-color: #d63638;
-}
-
-.cfwc-delete-all:hover:not(.confirm-delete) {
-	background: #fbeaea;
-	border-color: #d63638;
-	color: #d63638;
-}
-
-.cfwc-delete-all.confirm-delete {
-	background: #d63638 !important;
-	border-color: #d63638 !important;
-	color: #fff !important;
-}
-
-/* Inline delete warning message */
-.cfwc-delete-warning {
-	margin-left: 10px;
-	color: #d63638;
-	font-weight: 600;
-	font-size: 13px;
-	animation: fadeIn 0.3s ease-in;
-}
-
-@keyframes fadeIn {
-	from {
-	opacity: 0;
-	}
-	to {
-	opacity: 1;
-	}
-}
-
-/* Help link icon removed for cleaner look */
-
-/* Column widths are now defined above in the main table styles */
-
-/* Preset Button Styles */
-.cfwc-preset-loader button {
-	margin-right: 10px;
-	margin-bottom: 5px;
-}
-
-.cfwc-preset-loader .cfwc-replace-preset {
-	background: #2271b1;
-	border-color: #2271b1;
-	color: #fff;
-}
-
-.cfwc-preset-loader .cfwc-replace-preset:hover:not(.confirm-replace) {
-	background: #135e96;
-	border-color: #135e96;
-	color: #fff;
-}
-
-.cfwc-preset-loader .cfwc-replace-preset.confirm-replace {
-	background: #d63638 !important;
-	border-color: #d63638 !important;
-	color: #fff !important;
-}
-
-.cfwc-preset-loader select,
-.cfwc-preset-loader .select2-container {
-	min-width: 280px;
-	margin-right: 10px;
-}
-
-/* Style the Select2 container to match WooCommerce */
-.cfwc-preset-loader .select2-container .select2-selection--single {
-	height: 32px;
-	line-height: 30px;
-}
-
-.cfwc-preset-loader
-	.select2-container--default
-	.select2-selection--single
-	.select2-selection__rendered {
-	padding-left: 8px;
-	padding-right: 20px;
-	line-height: 30px;
-}
-
-.cfwc-preset-loader
-	.select2-container--default
-	.select2-selection--single
-	.select2-selection__arrow {
-	height: 30px;
-}
-
-/* WP 7.0+ overrides for the preset-loader Select2. */
-body[class*="branch-7"] .cfwc-preset-loader .select2-container .select2-selection--single {
-	height: 40px;
-	line-height: 38px;
-}
-
-body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2-selection--single .select2-selection__rendered {
-	line-height: 38px;
-}
-
-body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2-selection--single .select2-selection__arrow {
-	height: 38px;
-}
-
-/* Mobile Responsive Styles */
-@media screen and (max-width: 768px) {
-	/* Default Product Origin Section */
-	#cfwc_default_origin_select {
-	width: 100% !important;
-	margin-left: 0 !important;
-	margin-top: 10px;
-	}
-
-	/* Rules Header - Stack on mobile */
-	.cfwc-rules-header {
-	flex-direction: column;
-	align-items: flex-start;
-	}
-
-	.cfwc-add-rule,
-	.cfwc-delete-all {
-	width: auto;
-	min-width: 100px;
-	font-size: 13px;
-	padding: 3px 8px;
-	}
-
-	/* Preset buttons responsive */
-	.cfwc-preset-loader {
-	display: flex;
-	flex-direction: column;
-	gap: 10px;
-	}
-
-	.cfwc-preset-loader select,
-	.cfwc-preset-loader .select2-container {
-	width: 100% !important;
-	min-width: 0;
-	margin-right: 0;
-	margin-bottom: 10px;
-	}
-
-	.cfwc-preset-loader button {
-	width: 100%;
-	margin-right: 0;
-	}
-
-	/* Rules table - make it scrollable on mobile */
-	.cfwc-rules-table-wrapper {
-	overflow-x: auto;
-	-webkit-overflow-scrolling: touch;
-	}
-
-	.cfwc-rules-table {
-	min-width: 700px; /* Maintain minimum width for readability */
-	}
-
-	/* Modal full screen on mobile */
-	.cfwc-modal-content {
-	width: 100%;
-	height: 100%;
-	max-width: none;
-	max-height: none;
-	border-radius: 0;
-	transform: none;
-	position: fixed;
-	top: 0;
-	left: 0;
-	}
-
-	/* Form fields in rules */
-	.cfwc-rule-form input[type="text"],
-	.cfwc-rule-form input[type="number"],
-	.cfwc-rule-form select {
-	width: 100%;
-	margin-bottom: 5px;
-	}
-
-	.cfwc-stacking-select {
-	width: 100%;
-	}
-}
-
-@media screen and (max-width: 480px) {
-	/* Even smaller screens */
-	.cfwc-rules-table {
-	font-size: 12px;
-	}
-
-	.cfwc-rules-table th,
-	.cfwc-rules-table td {
-	padding: 5px;
-	}
-
-	.cfwc-help-link-under {
-	font-size: 12px;
-	}
-
-	.button {
-	padding: 5px 10px;
-	font-size: 13px;
-	}
-}
-
-/* ==========================================================================
-	Rules table column widths
-	========================================================================== */
-
+/* Current 9-column layout via cfwc-col-* classes. */
 .cfwc-rules-table .cfwc-col-label,
 .cfwc-rules-table .cfwc-col-countries,
 .cfwc-rules-table .cfwc-col-products {
@@ -753,10 +109,7 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 	width: 8%;
 }
 
-/* ==========================================================================
-	Rules table inline content
-	========================================================================== */
-
+/* Inline cell content */
 .cfwc-rules-table .cfwc-priority-meta {
 	color: #666;
 	font-size: 11px;
@@ -777,43 +130,91 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 	font-size: 11px;
 }
 
-/* ==========================================================================
-	Badges
-	========================================================================== */
-
-.cfwc-rule-badge {
-	display: inline-block;
-	padding: 3px 8px;
-	color: #fff;
-	border-radius: 3px;
-	font-size: 11px;
-	font-weight: 600;
-	line-height: 1;
-}
-
-.cfwc-rule-badge--valuation {
-	background: #2271b1;
-}
-
-.cfwc-rule-badge--dependency {
-	background: #8261a1;
-}
-
-.cfwc-rule-badge--stacking-add {
-	background: #46b450;
-}
-
-.cfwc-rule-badge--stacking-override {
-	background: #f0ad4e;
-}
-
-.cfwc-rule-badge--stacking-exclusive {
-	background: #dc3232;
+.no-rules td {
+	padding: 20px;
+	color: #646970;
+	font-style: italic;
+	text-align: center;
 }
 
 /* ==========================================================================
-	Rule row form fields (used by rules table edit/add rows in admin.js)
-	========================================================================== */
+   Rule row (view mode)
+   ========================================================================== */
+
+.cfwc-rule-row td {
+	background: #fff;
+	transition: background-color 0.2s;
+}
+
+.cfwc-rule-row:hover td {
+	background: #f8f9fa;
+}
+
+/* ==========================================================================
+   Rule row (editing mode)
+   ========================================================================== */
+
+.cfwc-rule-editing {
+	height: auto;
+	background: #f0f6fc !important;
+	border: 1px solid #0073aa;
+}
+
+.cfwc-rule-editing td {
+	position: relative;
+	padding: 6px 4px;
+	overflow: visible;
+}
+
+.cfwc-rule-editing input[type="text"],
+.cfwc-rule-editing input[type="number"] {
+	width: calc(100% - 4px);
+	max-width: 100%;
+	padding: 4px 6px;
+	font-size: 13px;
+	border: 1px solid #8c8f94;
+	box-sizing: border-box;
+}
+
+.cfwc-rule-editing select:not(.select2-hidden-accessible) {
+	width: 100%;
+	max-width: 100%;
+	padding: 4px;
+	font-size: 13px;
+	border: 1px solid #8c8f94;
+	box-sizing: border-box;
+}
+
+/* Select2 / SelectWoo widgets inside the editing row. */
+.cfwc-rule-editing .wc-enhanced-select,
+.cfwc-country-select {
+	width: 100% !important;
+	min-width: 150px !important;
+	max-width: 100% !important;
+}
+
+.cfwc-rule-editing .select2-container {
+	display: block !important;
+	width: 100% !important;
+	max-width: 100% !important;
+	box-sizing: border-box !important;
+}
+
+.cfwc-rule-editing .select2-container--default .select2-selection--single {
+	height: 28px;
+	padding: 0 20px 0 5px;
+	font-size: 13px;
+	line-height: 26px;
+}
+
+/* ==========================================================================
+   Rule row form fields (JS-rendered edit/add rows)
+   ========================================================================== */
+
+.cfwc-rule-field {
+	width: 100%;
+	max-width: 100%;
+}
 
 .cfwc-rule-row .cfwc-rule-field {
 	width: 100%;
@@ -833,15 +234,10 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 	width: 80px;
 }
 
-.cfwc-rule-row .cfwc-country-spacer {
-	display: inline-block;
-	width: 10px;
-}
-
 .cfwc-rule-row .cfwc-field-spacer {
 	display: none;
-	height: 5px;
 	width: 100%;
+	height: 5px;
 }
 
 .cfwc-rule-row .cfwc-field-spacer.is-visible {
@@ -849,10 +245,10 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 }
 
 .cfwc-rule-row .cfwc-field-help {
-	font-size: 11px;
-	color: #666;
-	margin-top: 2px;
 	display: block;
+	margin-top: 2px;
+	color: #666;
+	font-size: 11px;
 }
 
 .cfwc-rule-row .cfwc-field-help--inline {
@@ -861,16 +257,12 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 
 .cfwc-rule-row .cfwc-field-required {
 	display: block;
-	font-size: 11px;
-	color: #999;
 	margin-top: 2px;
+	color: #999;
+	font-size: 11px;
 }
 
 .cfwc-rule-row .cfwc-stacking-help span {
-	display: none;
-}
-
-.cfwc-rule-row .is-hidden {
 	display: none;
 }
 
@@ -878,126 +270,52 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 	display: inline;
 }
 
-/* ==========================================================================
-	Delete confirmation warning
-	========================================================================== */
+.cfwc-rule-row .is-hidden {
+	display: none;
+}
 
-.cfwc-delete-warning {
-	color: #d63638;
-	margin-left: 10px;
+/* ==========================================================================
+   Rule badges
+   ========================================================================== */
+
+.cfwc-rule-badge {
+	display: inline-block;
+	padding: 3px 8px;
+	color: #fff;
+	font-size: 11px;
 	font-weight: 600;
+	line-height: 1;
+	border-radius: 3px;
 }
 
-.button.confirm-delete,
-.button.confirm-replace {
-	background: #d63638;
-	color: #fff;
-	border-color: #d63638;
-}
-
-.button.confirm-delete:hover,
-.button.confirm-replace:hover {
-	background: #b32d2e;
-	color: #fff;
-}
+.cfwc-rule-badge--valuation        { background: #2271b1; }
+.cfwc-rule-badge--dependency       { background: #8261a1; }
+.cfwc-rule-badge--stacking-add     { background: #46b450; }
+.cfwc-rule-badge--stacking-override{ background: #f0ad4e; }
+.cfwc-rule-badge--stacking-exclusive { background: #dc3232; }
 
 /* ==========================================================================
-	Edit-screen meta box helpers (class-cfwc-admin.php)
-	========================================================================== */
+   Rules header (title + actions row)
+   ========================================================================== */
 
-.cfwc-fees-breakdown-list {
-	margin: 10px 0;
-	padding-left: 20px;
+.cfwc-rules-header {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 15px;
+	justify-content: space-between;
+	align-items: flex-start;
+	margin: 30px 0 20px;
 }
 
-.cfwc-fees-breakdown-list li {
-	margin: 5px 0;
+.cfwc-rules-header h3 {
+	margin: 0;
+	font-size: 1.3em;
 }
 
-.cfwc-fees-divider {
-	margin: 10px 0;
-}
-
-.cfwc-section-divider {
-	margin: 15px 0;
-}
-
-.cfwc-product-customs-list {
-	margin: 10px 0 0 20px;
-}
-
-/* ==========================================================================
-	Product edit screen
-	========================================================================== */
-
-.cfwc-product-fields-heading {
-	margin: 10px 12px 5px;
+.cfwc-rules-header p {
+	margin: 0;
+	color: #666;
 	font-size: 14px;
-	font-weight: 600;
-}
-
-.cfwc-hs-code-help {
-	margin-left: 154px;
-	margin-top: -10px;
-	margin-bottom: 10px;
-	font-size: 12px;
-	color: #666;
-}
-
-/* ==========================================================================
-	Order item meta (admin order screen)
-	========================================================================== */
-
-.cfwc-order-item-meta {
-	margin-top: 0.5em;
-}
-
-/* ==========================================================================
-	Onboarding notice
-	========================================================================== */
-
-.cfwc-dismiss-notice {
-	margin-left: 15px;
-}
-
-/* ==========================================================================
-	Settings: default origin select
-	========================================================================== */
-
-#cfwc_default_origin_select {
-	width: 350px;
-	max-width: 50%;
-}
-
-/* ==========================================================================
-	Settings: rules section header / preset / notices
-	========================================================================== */
-
-.cfwc-default-origin-help {
-	display: block;
-	margin: 2px 0 8px 24px;
-	color: #666;
-}
-
-.cfwc-help-link-under {
-	margin-top: 10px;
-}
-
-.cfwc-help-link-under .dashicons-info {
-	color: #2271b1;
-}
-
-.cfwc-rules-divider {
-	margin: 40px 0 30px 0;
-	border-top: 1px solid #c3c4c7;
-}
-
-.cfwc-notices-container {
-	margin-bottom: 20px;
-}
-
-.cfwc-notices-container > .notice {
-	margin-bottom: 10px;
 }
 
 .cfwc-rules-header-info {
@@ -1020,72 +338,330 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 	align-self: flex-start;
 }
 
+.cfwc-rules-divider {
+	margin: 40px 0 30px;
+	border-top: 1px solid #c3c4c7;
+}
+
+/* ==========================================================================
+   Help link under header
+   ========================================================================== */
+
+.cfwc-help-link-under {
+	display: inline-flex;
+	align-items: center;
+	margin-top: 10px;
+	color: #2271b1;
+	font-size: 13px;
+	text-decoration: none;
+}
+
+.cfwc-help-link-under:hover {
+	color: #135e96;
+	text-decoration: none;
+}
+
+.cfwc-help-link-under:hover .cfwc-help-text {
+	text-decoration: underline;
+}
+
+.cfwc-help-link-under .dashicons-info {
+	color: #2271b1;
+}
+
+/* ==========================================================================
+   Buttons (add / delete / confirm states)
+   ========================================================================== */
+
+.cfwc-add-rule,
+.cfwc-delete-all {
+	white-space: nowrap;
+}
+
+.cfwc-add-rule:hover {
+	background: #f0f0f1;
+	border-color: #0a4b78;
+	color: #0a4b78;
+}
+
+.cfwc-delete-all {
+	color: #d63638;
+	border-color: #d63638;
+}
+
+.cfwc-delete-all:hover:not(.confirm-delete) {
+	background: #fbeaea;
+	border-color: #d63638;
+	color: #d63638;
+}
+
+.cfwc-delete-all.confirm-delete {
+	background: #d63638 !important;
+	border-color: #d63638 !important;
+	color: #fff !important;
+}
+
+.cfwc-delete-rule:hover {
+	color: #d63638;
+	border-color: #d63638;
+}
+
+.cfwc-delete-warning {
+	margin-left: 10px;
+	color: #d63638;
+	font-size: 13px;
+	font-weight: 600;
+	animation: fadeIn 0.3s ease-in;
+}
+
+.button.confirm-delete,
+.button.confirm-replace {
+	background: #d63638;
+	border-color: #d63638;
+	color: #fff;
+}
+
+.button.confirm-delete:hover,
+.button.confirm-replace:hover {
+	background: #b32d2e;
+	color: #fff;
+}
+
+/* ==========================================================================
+   Preset loader
+   ========================================================================== */
+
+.cfwc-preset-loader {
+	margin: 40px 0 30px;
+}
+
+.cfwc-preset-loader h3 {
+	margin: 0 0 15px;
+	font-size: 1.3em;
+}
+
+.cfwc-preset-loader p {
+	margin-bottom: 20px;
+}
+
+.cfwc-preset-loader button {
+	margin-right: 10px;
+	margin-bottom: 5px;
+}
+
+.cfwc-preset-loader select,
+.cfwc-preset-loader .select2-container {
+	min-width: 280px;
+	margin-right: 10px;
+}
+
+.cfwc-preset-loader .cfwc-replace-preset {
+	background: #2271b1;
+	border-color: #2271b1;
+	color: #fff;
+}
+
+.cfwc-preset-loader .cfwc-replace-preset:hover:not(.confirm-replace) {
+	background: #135e96;
+	border-color: #135e96;
+	color: #fff;
+}
+
+.cfwc-preset-loader .cfwc-replace-preset.confirm-replace {
+	background: #d63638 !important;
+	border-color: #d63638 !important;
+	color: #fff !important;
+}
+
+/* Match WooCommerce Select2 dimensions. */
+.cfwc-preset-loader .select2-container .select2-selection--single {
+	height: 32px;
+	line-height: 30px;
+}
+
+.cfwc-preset-loader .select2-container--default .select2-selection--single .select2-selection__rendered {
+	padding-right: 20px;
+	padding-left: 8px;
+	line-height: 30px;
+}
+
+.cfwc-preset-loader .select2-container--default .select2-selection--single .select2-selection__arrow {
+	height: 30px;
+}
+
 #cfwc-preset-select {
 	width: 280px;
 	max-width: 100%;
 }
 
+#cfwc-preset-description {
+	display: none;
+	margin-top: 10px;
+}
+
 /* ==========================================================================
-	WooCommerce-style modal (moved from rules-section.php inline <style>)
-	========================================================================== */
+   Default origin select
+   ========================================================================== */
+
+#cfwc_default_origin_select {
+	width: 350px;
+	max-width: 50%;
+}
+
+.cfwc-default-origin-help {
+	display: block;
+	margin: 2px 0 8px 24px;
+	color: #666;
+}
+
+/* ==========================================================================
+   Notices container
+   ========================================================================== */
+
+.cfwc-notices-container {
+	margin-bottom: 20px;
+}
+
+.cfwc-notices-container > .notice {
+	margin-bottom: 10px;
+}
+
+/* ==========================================================================
+   Product edit screen (Country of Origin Select2)
+   ========================================================================== */
+
+#_cfwc_country_of_origin {
+	width: 250px;
+}
+
+#_cfwc_country_of_origin + .select2-container,
+span[aria-labelledby="select2-_cfwc_country_of_origin-container"] {
+	width: 250px !important;
+}
+
+#select2-_cfwc_country_of_origin-results {
+	max-width: 250px !important;
+}
+
+.cfwc-product-fields-heading {
+	margin: 10px 12px 5px;
+	font-size: 14px;
+	font-weight: 600;
+}
+
+.cfwc-hs-code-help {
+	margin: -10px 0 10px 154px;
+	color: #666;
+	font-size: 12px;
+}
+
+/* ==========================================================================
+   Admin meta box (edit screen) / order item meta
+   ========================================================================== */
+
+.cfwc-fees-breakdown-list {
+	margin: 10px 0;
+	padding-left: 20px;
+}
+
+.cfwc-fees-breakdown-list li {
+	margin: 5px 0;
+}
+
+.cfwc-fees-divider {
+	margin: 10px 0;
+}
+
+.cfwc-section-divider {
+	margin: 15px 0;
+}
+
+.cfwc-product-customs-list {
+	margin: 10px 0 0 20px;
+}
+
+.cfwc-order-item-meta {
+	margin-top: 0.5em;
+}
+
+/* ==========================================================================
+   Onboarding notice
+   ========================================================================== */
+
+.cfwc-dismiss-notice {
+	margin-left: 15px;
+}
+
+/* ==========================================================================
+   Save button stacking (above snackbar)
+   ========================================================================== */
+
+.woocommerce-save-button {
+	position: relative;
+	z-index: 10;
+}
+
+/* ==========================================================================
+   Modal (WooCommerce-style)
+   ========================================================================== */
 
 .cfwc-modal {
 	position: fixed;
 	top: 0;
-	left: 0;
 	right: 0;
 	bottom: 0;
+	left: 0;
 	z-index: 160000;
 }
 
 .cfwc-modal-backdrop {
 	position: fixed;
 	top: 0;
-	left: 0;
 	right: 0;
 	bottom: 0;
-	background: rgba(0, 0, 0, 0.6);
+	left: 0;
 	z-index: 159990;
+	background: rgba(0, 0, 0, 0.6);
 }
 
 .cfwc-modal-content {
 	position: absolute;
 	top: 50%;
 	left: 50%;
-	transform: translate(-50%, -50%);
+	z-index: 160000;
+	display: flex;
+	flex-direction: column;
 	width: 90%;
 	max-width: 600px;
 	max-height: 90vh;
 	background: #fff;
 	border-radius: 4px;
 	box-shadow: 0 3px 30px rgba(0, 0, 0, 0.2);
-	z-index: 160000;
-	display: flex;
-	flex-direction: column;
+	transform: translate(-50%, -50%);
 }
 
 .cfwc-modal-header {
-	padding: 20px;
-	border-bottom: 1px solid #e0e0e0;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+	padding: 20px;
+	border-bottom: 1px solid #e0e0e0;
 }
 
 .cfwc-modal-header h2 {
 	margin: 0;
+	color: #333;
 	font-size: 18px;
 	font-weight: 600;
-	color: #333;
 }
 
 .cfwc-modal-close {
+	padding: 0;
 	background: none;
 	border: none;
-	cursor: pointer;
-	padding: 0;
 	color: #999;
 	font-size: 20px;
+	cursor: pointer;
 }
 
 .cfwc-modal-close:hover {
@@ -1093,9 +669,9 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 }
 
 .cfwc-modal-body {
+	flex: 1;
 	padding: 20px;
 	overflow-y: auto;
-	flex: 1;
 }
 
 .cfwc-modal-footer {
@@ -1103,6 +679,10 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 	border-top: 1px solid #e0e0e0;
 	text-align: right;
 }
+
+/* ==========================================================================
+   Help section (inside modal)
+   ========================================================================== */
 
 .cfwc-help-section {
 	margin-bottom: 30px;
@@ -1113,17 +693,17 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 }
 
 .cfwc-help-section h3 {
-	margin: 0 0 15px 0;
+	margin: 0 0 15px;
+	color: #333;
 	font-size: 14px;
 	font-weight: 600;
-	color: #333;
 }
 
 .cfwc-help-section h3 .dashicons {
-	font-size: 18px;
-	vertical-align: middle;
 	margin-right: 5px;
 	color: #2271b1;
+	font-size: 18px;
+	vertical-align: middle;
 }
 
 .cfwc-help-section h3 .dashicons-lightbulb {
@@ -1134,87 +714,103 @@ body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2
 .cfwc-help-section ul {
 	margin: 0;
 	padding-left: 25px;
+	color: #555;
 	font-size: 14px;
 	line-height: 1.8;
-	color: #555;
 }
 
 .cfwc-help-section li {
 	margin-bottom: 8px;
 }
 
+.cfwc-help-section .cfwc-badge {
+	display: inline-block;
+	min-width: 70px;
+	padding: 4px 10px;
+	color: #fff;
+	font-size: 12px;
+	font-weight: 600;
+	text-align: center;
+	border-radius: 3px;
+}
+
+.cfwc-help-section .cfwc-badge-stack     { background: #46b450; }
+.cfwc-help-section .cfwc-badge-override  { background: #f0ad4e; }
+.cfwc-help-section .cfwc-badge-exclusive { background: #dc3232; }
+
 .cfwc-stacking-modes {
 	margin-top: 10px;
 }
 
 .cfwc-stacking-mode {
-	margin-bottom: 10px;
 	display: flex;
 	align-items: center;
 	gap: 10px;
-}
-
-.cfwc-help-section .cfwc-badge {
-	display: inline-block;
-	padding: 4px 10px;
-	border-radius: 3px;
-	font-size: 12px;
-	font-weight: 600;
-	color: #fff;
-	min-width: 70px;
-	text-align: center;
-}
-
-.cfwc-help-section .cfwc-badge-stack {
-	background: #46b450;
-}
-
-.cfwc-help-section .cfwc-badge-override {
-	background: #f0ad4e;
-}
-
-.cfwc-help-section .cfwc-badge-exclusive {
-	background: #dc3232;
-}
-
-@media screen and (max-width: 768px) {
-	.cfwc-modal-content {
-		width: 100%;
-		height: 100%;
-		max-width: none;
-		max-height: none;
-		border-radius: 0;
-		transform: none;
-		position: fixed;
-		top: 0;
-		left: 0;
-	}
-
-	#cfwc_default_origin_select {
-		width: 100% !important;
-		margin-left: 0 !important;
-		margin-top: 10px;
-	}
+	margin-bottom: 10px;
 }
 
 /* ==========================================================================
-	WordPress/Gutenberg snackbar repositioning (moved from admin.js inline <style>)
-	========================================================================== */
+   Select2 dropdown overflow guard
+   ========================================================================== */
+
+.select2-container--open .select2-dropdown {
+	min-width: 200px !important;
+	max-width: 400px !important;
+}
+
+/* ==========================================================================
+   Country select stacking gap (From above To)
+   ========================================================================== */
+
+.cfwc-country-select[data-field="from_country"] + .select2-container {
+	margin-bottom: 5px;
+}
+
+/* ==========================================================================
+   WP 7.0+ form-control height normalization (40px target)
+   ========================================================================== */
+
+body[class*="branch-7"] .cfwc-rules-table tbody tr {
+	height: 50px;
+}
+
+body[class*="branch-7"] .cfwc-rule-editing input[type="text"],
+body[class*="branch-7"] .cfwc-rule-editing input[type="number"],
+body[class*="branch-7"] .cfwc-rule-editing select:not(.select2-hidden-accessible),
+body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single,
+body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--multiple,
+body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single,
+body[class*="branch-7"] .cfwc-preset-loader .select2-container .select2-selection--single {
+	height: 40px;
+}
+
+body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single .select2-selection__rendered,
+body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single,
+body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single .select2-selection__rendered,
+body[class*="branch-7"] .cfwc-preset-loader .select2-container .select2-selection--single,
+body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2-selection--single .select2-selection__rendered {
+	line-height: 38px;
+}
+
+body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single .select2-selection__arrow,
+body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single .select2-selection__arrow,
+body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2-selection--single .select2-selection__arrow {
+	height: 38px;
+}
+
+/* ==========================================================================
+   Snackbar (WordPress/Gutenberg) — pin to bottom-right
+   ========================================================================== */
 
 body .components-snackbar-list,
 body .components-snackbar-list__notices-container {
 	position: fixed !important;
 	right: 20px !important;
-	left: auto !important;
 	bottom: 30px !important;
+	left: auto !important;
+	z-index: 100001 !important;
 	width: auto !important;
 	max-width: 400px !important;
-	z-index: 100001 !important;
-}
-
-body .components-snackbar {
-	margin-right: 0 !important;
-	margin-left: auto !important;
 }
 
 body.woocommerce_page_wc-settings .components-snackbar-list {
@@ -1222,17 +818,22 @@ body.woocommerce_page_wc-settings .components-snackbar-list {
 	left: auto !important;
 }
 
-@media (max-width: 782px) {
-	body .components-snackbar-list {
-		right: 10px !important;
-		bottom: 80px !important;
-		max-width: calc(100vw - 20px) !important;
-	}
+body .components-snackbar {
+	margin-right: 0 !important;
+	margin-left: auto !important;
 }
 
-.woocommerce .submit {
-	position: relative !important;
-	z-index: 99999 !important;
+.components-snackbar-list {
+	display: flex;
+	gap: 15px;
+	justify-content: flex-start;
+	pointer-events: none;
+}
+
+.components-snackbar-list .components-snackbar {
+	max-width: 600px;
+	margin: 0;
+	pointer-events: auto;
 }
 
 body.woocommerce_page_wc-settings {
@@ -1240,34 +841,29 @@ body.woocommerce_page_wc-settings {
 }
 
 /* ==========================================================================
-	Fallback admin notice (used by admin.js when wp.data unavailable)
-	========================================================================== */
+   Fallback admin notice (used by admin.js when wp.data unavailable)
+   ========================================================================== */
 
 .cfwc-admin-notice-wrapper {
 	position: fixed;
 	right: 20px;
 	bottom: 30px;
-	max-width: 400px;
 	z-index: 100001;
+	max-width: 400px;
+	padding: 12px;
 	background: #fff;
 	border-left: 4px solid #46b450;
 	box-shadow: 0 1px 1px 0 rgba(0, 0, 0, 0.1);
-	padding: 12px;
 }
 
-.cfwc-admin-notice-wrapper.is-error {
-	border-left-color: #dc3232;
-}
-
-.cfwc-admin-notice-wrapper.is-warning {
-	border-left-color: #ffb900;
-}
+.cfwc-admin-notice-wrapper.is-error   { border-left-color: #dc3232; }
+.cfwc-admin-notice-wrapper.is-warning { border-left-color: #ffb900; }
 
 .cfwc-admin-notice-wrapper .notice {
 	margin: 0;
+	padding: 0;
 	border: none;
 	box-shadow: none;
-	padding: 0;
 }
 
 .cfwc-admin-notice-wrapper .notice p {
@@ -1278,4 +874,117 @@ body.woocommerce_page_wc-settings {
 	position: absolute;
 	top: 0;
 	right: 0;
+}
+
+/* ==========================================================================
+   Responsive
+   ========================================================================== */
+
+@media screen and (max-width: 1024px) {
+	.cfwc-rules-table {
+		font-size: 12px;
+	}
+
+	.cfwc-rules-table th,
+	.cfwc-rules-table td {
+		padding: 6px 4px;
+	}
+
+	.cfwc-rule-editing input,
+	.cfwc-rule-editing select {
+		font-size: 12px;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	body .components-snackbar-list {
+		right: 10px !important;
+		bottom: 80px !important;
+		max-width: calc(100vw - 20px) !important;
+	}
+}
+
+@media screen and (max-width: 768px) {
+	#cfwc_default_origin_select {
+		width: 100% !important;
+		margin-top: 10px;
+		margin-left: 0 !important;
+	}
+
+	.cfwc-rules-header {
+		flex-direction: column;
+		align-items: flex-start;
+	}
+
+	.cfwc-add-rule,
+	.cfwc-delete-all {
+		width: auto;
+		min-width: 100px;
+		padding: 3px 8px;
+		font-size: 13px;
+	}
+
+	.cfwc-preset-loader {
+		display: flex;
+		flex-direction: column;
+		gap: 10px;
+	}
+
+	.cfwc-preset-loader select,
+	.cfwc-preset-loader .select2-container {
+		width: 100% !important;
+		min-width: 0;
+		margin-right: 0;
+		margin-bottom: 10px;
+	}
+
+	.cfwc-preset-loader button {
+		width: 100%;
+		margin-right: 0;
+	}
+
+	.cfwc-rules-table-wrapper {
+		overflow-x: auto;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	.cfwc-rules-table {
+		min-width: 700px;
+	}
+
+	.cfwc-stacking-select {
+		width: 100%;
+	}
+
+	.cfwc-modal-content {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		max-width: none;
+		max-height: none;
+		border-radius: 0;
+		transform: none;
+	}
+}
+
+@media screen and (max-width: 480px) {
+	.cfwc-rules-table {
+		font-size: 12px;
+	}
+
+	.cfwc-rules-table th,
+	.cfwc-rules-table td {
+		padding: 5px;
+	}
+
+	.cfwc-help-link-under {
+		font-size: 12px;
+	}
+
+	.button {
+		padding: 5px 10px;
+		font-size: 13px;
+	}
 }

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -340,3 +340,62 @@ ul.cfwc-fees-breakdown li:before,
 	padding: 8px;
 	}
 }
+
+/* ==========================================================================
+	Order details: customer-facing customs info box (class-cfwc-display.php)
+	========================================================================== */
+
+.cfwc-customs-info-box {
+	margin: 30px 0;
+	padding: 20px;
+	background-color: #e8f4f8;
+	border-left: 4px solid #0073aa;
+}
+
+.cfwc-customs-info-box__title {
+	margin: 0 0 10px;
+	color: #0073aa;
+	font-size: 16px;
+}
+
+.cfwc-customs-info-box__lead {
+	margin: 0 0 10px;
+	color: #666;
+	font-size: 14px;
+}
+
+.cfwc-customs-info-box__total {
+	margin: 0 0 10px;
+	color: #333;
+	font-size: 14px;
+}
+
+.cfwc-customs-info-box__disclaimer {
+	margin: 0;
+	color: #999;
+	font-size: 12px;
+	font-style: italic;
+}
+
+/* ==========================================================================
+	Order details: fee breakdown wrapper / line items
+	========================================================================== */
+
+.cfwc-fees-breakdown-wrapper {
+	display: block;
+}
+
+.cfwc-fees-breakdown-wrapper .cfwc-fee-item {
+	display: block;
+	margin: 0 0 5px 0;
+	padding: 0;
+}
+
+/* ==========================================================================
+	Order item small meta line (HS code / origin under item name)
+	========================================================================== */
+
+.cfwc-order-item-extra {
+	color: #666;
+	font-size: 0.9em;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -722,6 +722,31 @@
       return html;
     }
 
+    // Populate base_includes select options from existing rules.
+    function populateBaseIncludesSelect($select, currentRuleId, selectedValues) {
+      var rules = JSON.parse($("#cfwc_rules").val() || "[]");
+      var optionsHtml = "";
+      $.each(rules, function (i, r) {
+        var rid = r.rule_id || "";
+        var label = r.label || rid || "Rule " + i;
+        if (rid && rid !== currentRuleId) {
+          var selected =
+            selectedValues && selectedValues.indexOf(rid) !== -1
+              ? " selected"
+              : "";
+          optionsHtml +=
+            '<option value="' +
+            escapeHtml(rid) +
+            '"' +
+            selected +
+            ">" +
+            escapeHtml(label) +
+            "</option>";
+        }
+      });
+      $select.html(optionsHtml);
+    }
+
     // Store state for edit/add operations.
     var originalRules = null;
     var editingIndex = null;
@@ -885,6 +910,15 @@
         initCountrySelect(
           ".cfwc-rules-table tbody tr:last .cfwc-category-select"
         );
+        var $baseIncludes = $(
+          ".cfwc-rules-table tbody tr:last .cfwc-base-includes-select"
+        );
+        populateBaseIncludesSelect($baseIncludes, newRuleId, []);
+        if ($baseIncludes.length && typeof $.fn.selectWoo !== "undefined") {
+          $baseIncludes.selectWoo({ width: "100%", placeholder: "Select fees to include in base" });
+        } else if ($baseIncludes.length && $.fn.select2) {
+          $baseIncludes.select2({ width: "100%", placeholder: "Select fees to include in base" });
+        }
       }, 100);
 
       // Scroll to new row.
@@ -1164,6 +1198,25 @@
       // Initialize Select2 on selects.
       initCountrySelect($row.find(".cfwc-country-select"));
       initCountrySelect($row.find(".cfwc-category-select"));
+
+      // Populate and init base_includes select.
+      var $baseIncludes = $row.find(".cfwc-base-includes-select");
+      populateBaseIncludesSelect(
+        $baseIncludes,
+        rule.rule_id || "",
+        currentBaseIncludes
+      );
+      if ($baseIncludes.length && typeof $.fn.selectWoo !== "undefined") {
+        $baseIncludes.selectWoo({
+          width: "100%",
+          placeholder: "Select fees to include in base",
+        });
+      } else if ($baseIncludes.length && $.fn.select2) {
+        $baseIncludes.select2({
+          width: "100%",
+          placeholder: "Select fees to include in base",
+        });
+      }
 
       // Handle match type change to show/hide fields.
       $row.find(".cfwc-match-type").on("change", function () {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -843,6 +843,24 @@
         '<td><input type="number" name="cfwc_rule_rate" class="cfwc-rule-field" data-field="rate" value="0" step="0.01" style="width: 80px;" required />' +
         '<span style="font-size: 11px; color: #999; display: block; margin-top: 2px;">Required *</span></td>';
 
+      // Valuation method.
+      newRowHtml += "<td>";
+      newRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
+      newRowHtml += '<option value="inherit">Inherit global</option>';
+      newRowHtml += '<option value="fob">FOB</option>';
+      newRowHtml += '<option value="cif">CIF</option>';
+      newRowHtml += '<option value="cif_insurance">CIF + Insurance</option>';
+      newRowHtml += "</select>";
+      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Overrides global for this rule</span>';
+      newRowHtml += "</td>";
+
+      // Depends on (base_includes) - hidden for flat type.
+      newRowHtml += '<td class="cfwc-base-includes-cell">';
+      newRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
+      newRowHtml += "</select>";
+      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Select fees to include in base</span>';
+      newRowHtml += "</td>";
+
       // Stacking mode.
       newRowHtml += "<td>";
       newRowHtml +=
@@ -862,24 +880,6 @@
       newRowHtml +=
         '<span class="stacking-help-exclusive" style="display: none;">No other rules apply</span>';
       newRowHtml += "</span>";
-      newRowHtml += "</td>";
-
-      // Valuation method.
-      newRowHtml += "<td>";
-      newRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
-      newRowHtml += '<option value="inherit">Inherit global</option>';
-      newRowHtml += '<option value="fob">FOB</option>';
-      newRowHtml += '<option value="cif">CIF</option>';
-      newRowHtml += '<option value="cif_insurance">CIF + Insurance</option>';
-      newRowHtml += "</select>";
-      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Overrides global for this rule</span>';
-      newRowHtml += "</td>";
-
-      // Depends on (base_includes) - hidden for flat type.
-      newRowHtml += '<td class="cfwc-base-includes-cell">';
-      newRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
-      newRowHtml += "</select>";
-      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Select fees to include in base</span>';
       newRowHtml += "</td>";
 
       // Actions.
@@ -1123,6 +1123,26 @@
         '" step="0.01" style="width: 80px;" required />' +
         '<span style="font-size: 11px; color: #999; display: block; margin-top: 2px;">Required *</span></td>';
 
+      // Valuation method.
+      var currentValuation = rule.valuation_method || "inherit";
+      editRowHtml += "<td>";
+      editRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
+      editRowHtml += '<option value="inherit"' + (currentValuation === "inherit" ? " selected" : "") + '>Inherit global</option>';
+      editRowHtml += '<option value="fob"' + (currentValuation === "fob" ? " selected" : "") + '>FOB</option>';
+      editRowHtml += '<option value="cif"' + (currentValuation === "cif" ? " selected" : "") + '>CIF</option>';
+      editRowHtml += '<option value="cif_insurance"' + (currentValuation === "cif_insurance" ? " selected" : "") + '>CIF + Insurance</option>';
+      editRowHtml += "</select>";
+      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Overrides global for this rule</span>';
+      editRowHtml += "</td>";
+
+      // Depends on (base_includes).
+      var currentBaseIncludes = rule.base_includes || [];
+      editRowHtml += '<td class="cfwc-base-includes-cell">';
+      editRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
+      editRowHtml += "</select>";
+      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Select fees to include in base</span>';
+      editRowHtml += "</td>";
+
       // Stacking mode.
       editRowHtml += "<td>";
       editRowHtml +=
@@ -1156,26 +1176,6 @@
         (currentMode === "exclusive" ? "" : "display: none;") +
         '">No other rules apply</span>';
       editRowHtml += "</span>";
-      editRowHtml += "</td>";
-
-      // Valuation method.
-      var currentValuation = rule.valuation_method || "inherit";
-      editRowHtml += "<td>";
-      editRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
-      editRowHtml += '<option value="inherit"' + (currentValuation === "inherit" ? " selected" : "") + '>Inherit global</option>';
-      editRowHtml += '<option value="fob"' + (currentValuation === "fob" ? " selected" : "") + '>FOB</option>';
-      editRowHtml += '<option value="cif"' + (currentValuation === "cif" ? " selected" : "") + '>CIF</option>';
-      editRowHtml += '<option value="cif_insurance"' + (currentValuation === "cif_insurance" ? " selected" : "") + '>CIF + Insurance</option>';
-      editRowHtml += "</select>";
-      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Overrides global for this rule</span>';
-      editRowHtml += "</td>";
-
-      // Depends on (base_includes).
-      var currentBaseIncludes = rule.base_includes || [];
-      editRowHtml += '<td class="cfwc-base-includes-cell">';
-      editRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
-      editRowHtml += "</select>";
-      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Select fees to include in base</span>';
       editRowHtml += "</td>";
 
       // Actions.

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -736,8 +736,12 @@
       isAddingNew = true;
       editingIndex = originalRules.length;
 
+      // Generate rule_id for new rules.
+      var newRuleId = "rule_" + Date.now().toString(36) + Math.random().toString(36).substr(2, 5);
+
       // Create new row HTML (editable fields).
       var newRowHtml = '<tr class="cfwc-rule-row cfwc-rule-editing">';
+      newRowHtml += '<input type="hidden" class="cfwc-rule-field" data-field="rule_id" value="' + newRuleId + '" />';
 
       // Label input with priority (first column).
       newRowHtml +=
@@ -835,6 +839,24 @@
       newRowHtml += "</span>";
       newRowHtml += "</td>";
 
+      // Valuation method.
+      newRowHtml += "<td>";
+      newRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
+      newRowHtml += '<option value="inherit">Inherit global</option>';
+      newRowHtml += '<option value="fob">FOB</option>';
+      newRowHtml += '<option value="cif">CIF</option>';
+      newRowHtml += '<option value="cif_insurance">CIF + Insurance</option>';
+      newRowHtml += "</select>";
+      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Overrides global for this rule</span>';
+      newRowHtml += "</td>";
+
+      // Depends on (base_includes) - hidden for flat type.
+      newRowHtml += '<td class="cfwc-base-includes-cell">';
+      newRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
+      newRowHtml += "</select>";
+      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Select fees to include in base</span>';
+      newRowHtml += "</td>";
+
       // Actions.
       newRowHtml += "<td>";
       newRowHtml +=
@@ -918,6 +940,9 @@
 
       // Create edit row HTML matching the new structure.
       var editRowHtml = "";
+
+      // Hidden rule_id field.
+      editRowHtml += '<input type="hidden" class="cfwc-rule-field" data-field="rule_id" value="' + (rule.rule_id || "") + '" />';
 
       // Label input with priority (first column).
       editRowHtml +=
@@ -1099,6 +1124,26 @@
       editRowHtml += "</span>";
       editRowHtml += "</td>";
 
+      // Valuation method.
+      var currentValuation = rule.valuation_method || "inherit";
+      editRowHtml += "<td>";
+      editRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
+      editRowHtml += '<option value="inherit"' + (currentValuation === "inherit" ? " selected" : "") + '>Inherit global</option>';
+      editRowHtml += '<option value="fob"' + (currentValuation === "fob" ? " selected" : "") + '>FOB</option>';
+      editRowHtml += '<option value="cif"' + (currentValuation === "cif" ? " selected" : "") + '>CIF</option>';
+      editRowHtml += '<option value="cif_insurance"' + (currentValuation === "cif_insurance" ? " selected" : "") + '>CIF + Insurance</option>';
+      editRowHtml += "</select>";
+      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Overrides global for this rule</span>';
+      editRowHtml += "</td>";
+
+      // Depends on (base_includes).
+      var currentBaseIncludes = rule.base_includes || [];
+      editRowHtml += '<td class="cfwc-base-includes-cell">';
+      editRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
+      editRowHtml += "</select>";
+      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Select fees to include in base</span>';
+      editRowHtml += "</td>";
+
       // Actions.
       editRowHtml += "<td>";
       editRowHtml +=
@@ -1185,10 +1230,18 @@
               return parseInt(v);
             });
           }
+        } else if (field === "base_includes") {
+          // For multi-select base_includes.
+          value = $(this).val() || [];
         }
 
         ruleData[field] = value;
       });
+
+      // Ensure rule_id exists for new rules.
+      if (!ruleData.rule_id) {
+        ruleData.rule_id = "rule_" + Date.now().toString(36) + Math.random().toString(36).substr(2, 5);
+      }
 
       // Ensure all required fields are present.
       ruleData.taxable =
@@ -1388,7 +1441,7 @@
         // No rules - show "Import Preset Rules".
         addPresetBtn.text(strings.import_preset || "Import Preset Rules");
         tbody.append(
-          '<tr class="no-rules"><td colspan="7">' +
+          '<tr class="no-rules"><td colspan="9">' +
             (strings.no_rules ||
               "No rules configured. Use the preset loader above or add rules manually.") +
             "</td></tr>"
@@ -1493,6 +1546,37 @@
             row += "<td>" + (rule.rate || 0) + "%</td>";
           } else {
             row += "<td>" + currency_symbol + (rule.amount || 0) + "</td>";
+          }
+
+          // Valuation method badge.
+          var valuationMethod = rule.valuation_method || "inherit";
+          var valuationLabels = {
+            fob: "FOB",
+            cif: "CIF",
+            cif_insurance: "CIF + Ins",
+          };
+          if (valuationMethod !== "inherit") {
+            row += '<td><span style="display: inline-block; padding: 3px 8px; background: #2271b1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="Overrides global valuation">' + escapeHtml(valuationLabels[valuationMethod] || valuationMethod) + "</span></td>";
+          } else {
+            row += '<td><em style="color: #999; font-size: 11px;">Global</em></td>';
+          }
+
+          // Depends on (base_includes).
+          var baseIncludes = rule.base_includes || [];
+          if (baseIncludes.length > 0) {
+            var depLabels = [];
+            $.each(baseIncludes, function (i, depId) {
+              $.each(rules, function (j, r) {
+                if (r.rule_id === depId) {
+                  depLabels.push(r.label || depId);
+                  return false;
+                }
+              });
+            });
+            var depTitle = escapeHtml(depLabels.join(", "));
+            row += '<td><span style="display: inline-block; padding: 3px 8px; background: #8261a1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' + depTitle + '">+' + baseIncludes.length + " fee(s)</span></td>";
+          } else {
+            row += '<td><em style="color: #999; font-size: 11px;">-</em></td>';
           }
 
           // Stacking mode - Use WooCommerce-style badges to match PHP rendering.

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -56,13 +56,7 @@
           .prop("disabled", false)
           .removeClass("disabled")
           .removeAttr("disabled")
-          .addClass("button-primary")
-          .css({
-            background: "#2271b1",
-            cursor: "pointer",
-            opacity: "1",
-            "pointer-events": "auto",
-          });
+          .addClass("button-primary");
       });
 
       // Pulse animation to draw attention.
@@ -118,27 +112,30 @@
       var $spacer = $row.find(".cfwc-field-spacer");
 
       // Show fields based on match type.
+      // Note: addClass/removeClass("is-hidden") manages the initial render's class;
+      // .hide()/.show() also adds/removes jQuery's own inline display, so we
+      // toggle both to avoid the class+inline-style mismatch.
       if (matchType === "all") {
         // All Products - hide both category and HS code fields, show "Not required".
-        $categorySelect.hide().removeAttr("required");
-        $hsCodeInput.hide().removeAttr("required");
-        $spacer.hide();
+        $categorySelect.addClass("is-hidden").hide().removeAttr("required");
+        $hsCodeInput.addClass("is-hidden").hide().removeAttr("required");
+        $spacer.removeClass("is-visible");
         $requiredIndicator.show().html("Not required");
         $categorySelect.attr("data-placeholder", "Select categories...");
         $hsCodeInput.attr("placeholder", "HS Code (e.g., 6109* or 61,62)");
       } else if (matchType === "category") {
         // By Category - show only category field, hide HS code.
-        $categorySelect.show().attr("required", "required");
-        $hsCodeInput.hide().removeAttr("required");
-        $spacer.hide();
+        $categorySelect.removeClass("is-hidden").show().attr("required", "required");
+        $hsCodeInput.addClass("is-hidden").hide().removeAttr("required");
+        $spacer.removeClass("is-visible");
         $requiredIndicator.show().html("Required *");
         $categorySelect.attr("data-placeholder", "Select categories...");
         $hsCodeInput.attr("placeholder", "HS Code (e.g., 6109* or 61,62)");
       } else if (matchType === "hs_code") {
         // By HS Code - show both fields but category is not required.
-        $categorySelect.show().removeAttr("required");
-        $spacer.show().css("display", "block"); // Show spacer between fields.
-        $hsCodeInput.show().attr("required", "required");
+        $categorySelect.removeClass("is-hidden").show().removeAttr("required");
+        $spacer.addClass("is-visible"); // Show spacer between fields.
+        $hsCodeInput.removeClass("is-hidden").show().attr("required", "required");
         $requiredIndicator
           .show()
           .html("Category: Not required<br>HS Code: Required *");
@@ -149,9 +146,9 @@
         $hsCodeInput.attr("placeholder", "HS Code (e.g., 6109* or 61,62)");
       } else if (matchType === "combined") {
         // Category + HS Code - show both fields with spacing.
-        $categorySelect.show().attr("required", "required");
-        $spacer.show().css("display", "block"); // Show spacer between fields.
-        $hsCodeInput.show().attr("required", "required");
+        $categorySelect.removeClass("is-hidden").show().attr("required", "required");
+        $spacer.addClass("is-visible"); // Show spacer between fields.
+        $hsCodeInput.removeClass("is-hidden").show().attr("required", "required");
         $requiredIndicator.show().html("Both required *");
         $categorySelect.attr("data-placeholder", "Select categories...");
         $hsCodeInput.attr("placeholder", "HS Code (e.g., 6109* or 61,62)");
@@ -175,10 +172,12 @@
       var $helpContainer = $(this).siblings(".description");
 
       // Hide all help texts.
-      $helpContainer.find("span").hide();
+      $helpContainer.find("span").removeClass("is-visible");
 
       // Show the relevant help text.
-      $helpContainer.find(".stacking-help-" + stackingMode).show();
+      $helpContainer
+        .find(".stacking-help-" + stackingMode)
+        .addClass("is-visible");
     });
 
     // Add preset rules (primary action - adds to existing like WooCommerce tax rates).
@@ -211,16 +210,14 @@
       if (!$(this).hasClass("confirm-replace")) {
         $(this)
           .addClass("confirm-replace")
-          .text(strings.confirm_replace || "Click again to confirm")
-          .css("background", "#d63638");
+          .text(strings.confirm_replace || "Click again to confirm");
 
         // Reset after 5 seconds.
         var $btn = $(this);
         setTimeout(function () {
           $btn
             .removeClass("confirm-replace")
-            .text(strings.replace_all || "Replace All Rules")
-            .css("background", "");
+            .text(strings.replace_all || "Replace All Rules");
         }, 5000);
         return;
       }
@@ -282,9 +279,7 @@
         // Reset button immediately (before showing success).
         $button
           .removeClass("confirm-delete")
-          .text(strings.delete_all || "Delete All Rules")
-          .css("background", "")
-          .css("color", "");
+          .text(strings.delete_all || "Delete All Rules");
 
         // Show success notice after button reset.
         setTimeout(function () {
@@ -298,14 +293,12 @@
         // First click - show inline warning text instead of blocking notification.
         $button
           .addClass("confirm-delete")
-          .text(strings.confirm_delete || "Click to Confirm Delete")
-          .css("background", "#d63638")
-          .css("color", "#fff");
+          .text(strings.confirm_delete || "Click to Confirm Delete");
 
         // Add inline warning message next to button if not already present.
         if (!$button.next(".cfwc-delete-warning").length) {
           $button.after(
-            '<span class="cfwc-delete-warning" style="color: #d63638; margin-left: 10px; font-weight: 600;">' +
+            '<span class="cfwc-delete-warning">' +
               "⚠️ This will delete ALL rules. Click again to confirm." +
               "</span>"
           );
@@ -315,9 +308,7 @@
         deleteButtonTimeout = setTimeout(function () {
           $button
             .removeClass("confirm-delete")
-            .text(strings.delete_all || "Delete All Rules")
-            .css("background", "")
-            .css("color", "");
+            .text(strings.delete_all || "Delete All Rules");
           $button.next(".cfwc-delete-warning").fadeOut(300, function () {
             $(this).remove();
           });
@@ -459,69 +450,8 @@
     // Show admin notice using WooCommerce snackbar.
     var noticeTimeout = null;
     var activeNoticeIds = []; // Track active notice IDs for proper cleanup.
-    var notificationStylesApplied = false;
-
-    // Apply notification positioning styles.
-    function applyNotificationStyles() {
-      if (notificationStylesApplied) return;
-
-      // Wait for DOM to be ready.
-      $(document).ready(function () {
-        // Inject CSS to reposition ALL types of notifications.
-        var styles =
-          '<style id="cfwc-notification-positioning">' +
-          // Move WordPress/Gutenberg snackbar notifications to right side
-          "body .components-snackbar-list, " +
-          "body .components-snackbar-list__notices-container {" +
-          "  position: fixed !important;" +
-          "  right: 20px !important;" +
-          "  left: auto !important;" +
-          "  bottom: 30px !important;" +
-          "  width: auto !important;" +
-          "  max-width: 400px !important;" +
-          "  z-index: 100001 !important;" +
-          "}" +
-          // Individual snackbar styling
-          "body .components-snackbar {" +
-          "  margin-right: 0 !important;" +
-          "  margin-left: auto !important;" +
-          "}" +
-          // WooCommerce specific snackbar positioning
-          "body.woocommerce_page_wc-settings .components-snackbar-list {" +
-          "  right: 20px !important;" +
-          "  left: auto !important;" +
-          "}" +
-          // Mobile responsive
-          "@media (max-width: 782px) {" +
-          "  body .components-snackbar-list {" +
-          "    right: 10px !important;" +
-          "    bottom: 80px !important;" + // Higher on mobile to avoid mobile save button
-          "    max-width: calc(100vw - 20px) !important;" +
-          "  }" +
-          "}" +
-          // Ensure save button area is never covered
-          ".woocommerce .submit {" +
-          "  position: relative !important;" +
-          "  z-index: 99999 !important;" +
-          "}" +
-          // Add padding to bottom of page to ensure save button is never hidden
-          "body.woocommerce_page_wc-settings {" +
-          "  padding-bottom: 100px !important;" +
-          "}" +
-          "</style>";
-
-        // Remove existing styles if any and add new ones.
-        $("#cfwc-notification-positioning").remove();
-        $("head").append(styles);
-
-        notificationStylesApplied = true;
-      });
-    }
 
     function showNotice(message, type, clearPrevious) {
-      // Apply positioning styles first.
-      applyNotificationStyles();
-
       // Default clearPrevious to true for better UX.
       if (clearPrevious === undefined) {
         clearPrevious = true;
@@ -583,14 +513,6 @@
             },
           });
 
-          // Force repositioning after creating notice (backup measure).
-          setTimeout(function () {
-            $(".components-snackbar-list").css({
-              right: "20px",
-              left: "auto",
-              bottom: "30px",
-            });
-          }, 10);
         } catch (error) {
           // Fallback if notice system fails.
           console.warn("Notice system error:", error);
@@ -606,45 +528,32 @@
 
     // Separate fallback function for cleaner code.
     function showFallbackNotice(message, type) {
-      // Apply positioning styles.
-      applyNotificationStyles();
-
       // Remove any existing notices.
       $(".cfwc-admin-notice-wrapper").remove();
 
       // Determine notice type class.
       var noticeClass = "notice-success";
-      var borderColor = "#46b450"; // Green for success
+      var wrapperModifier = "";
       if (type === "error" || type === "notice-error") {
         noticeClass = "notice-error";
-        borderColor = "#dc3232"; // Red for error
+        wrapperModifier = " is-error";
       } else if (type === "warning" || type === "notice-warning") {
         noticeClass = "notice-warning";
-        borderColor = "#ffb900"; // Yellow for warning
+        wrapperModifier = " is-warning";
       }
 
-      // Create notice wrapper positioned on right side.
+      // Create notice wrapper (styled via .cfwc-admin-notice-wrapper in admin.css).
       var noticeWrapper =
-        '<div class="cfwc-admin-notice-wrapper" style="' +
-        "position: fixed; " +
-        "right: 20px; " +
-        "bottom: 30px; " +
-        "max-width: 400px; " +
-        "z-index: 100001; " +
-        "background: #fff; " +
-        "border-left: 4px solid " +
-        borderColor +
-        "; " +
-        "box-shadow: 0 1px 1px 0 rgba(0,0,0,.1); " +
-        "padding: 12px; " +
+        '<div class="cfwc-admin-notice-wrapper' +
+        wrapperModifier +
         '">' +
         '<div class="notice ' +
         noticeClass +
-        '" style="margin: 0; border: none; box-shadow: none; padding: 0;">' +
-        '<p style="margin: 0;">' +
+        '">' +
+        "<p>" +
         message +
         "</p>" +
-        '<button type="button" class="notice-dismiss" style="position: absolute; top: 0; right: 0;"><span class="screen-reader-text">Dismiss</span></button>' +
+        '<button type="button" class="notice-dismiss"><span class="screen-reader-text">Dismiss</span></button>' +
         "</div>" +
         "</div>";
 
@@ -667,11 +576,6 @@
         });
       }, 3000);
     }
-
-    // Apply styles on page load as well.
-    $(document).ready(function () {
-      applyNotificationStyles();
-    });
 
     // Build country options.
     function getCountryOptions(selectedCountry) {
@@ -771,29 +675,28 @@
       // Label input with priority (first column).
       newRowHtml +=
         "<td>" +
-        '<input type="text" name="cfwc_rule_label" class="cfwc-rule-field" data-field="label" value="" placeholder="' +
+        '<input type="text" name="cfwc_rule_label" class="cfwc-rule-field cfwc-rule-field--label" data-field="label" value="" placeholder="' +
         (strings.fee_label || "Fee label") +
-        '" style="width: 100%; margin-bottom: 5px;" />' +
-        '<input type="number" name="cfwc_rule_priority" class="cfwc-rule-field" data-field="priority" value="0" placeholder="Priority (0-100)" title="Higher priority rules are checked first (0-100)" style="width: 100%;" min="0" max="100" />' +
-        '<span style="font-size: 11px; color: #666; margin-top: 2px; display: inline-block;">Higher numbers = higher priority</span>' +
+        '" />' +
+        '<input type="number" name="cfwc_rule_priority" class="cfwc-rule-field" data-field="priority" value="0" placeholder="Priority (0-100)" title="Higher priority rules are checked first (0-100)" min="0" max="100" />' +
+        '<span class="cfwc-field-help cfwc-field-help--inline">Higher numbers = higher priority</span>' +
         "</td>";
 
       // Countries column (From and To).
       newRowHtml += "<td>";
       newRowHtml +=
-        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select" data-field="from_country" data-placeholder="' +
+        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select" data-field="from_country" data-placeholder="' +
         (strings.from_country || "From (any)") +
-        '" style="width: 47%;">';
+        '">';
       newRowHtml +=
         '<option value="">Any Origin</option>' + getCountryOptions("");
       newRowHtml += "</select>";
       // Add spacing between dropdowns.
+      newRowHtml += '<span class="cfwc-country-spacer">&nbsp;</span>';
       newRowHtml +=
-        '<span style="display: inline-block; width: 10px;">&nbsp;</span>';
-      newRowHtml +=
-        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select" data-field="to_country" data-placeholder="' +
+        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select" data-field="to_country" data-placeholder="' +
         (strings.to_country || "To (any)") +
-        '" style="width: 47%;">';
+        '">';
       newRowHtml +=
         '<option value="">Any Destination</option>' + getCountryOptions("");
       newRowHtml += "</select></td>";
@@ -801,7 +704,7 @@
       // Products column (Categories & HS Code).
       newRowHtml += "<td>";
       newRowHtml +=
-        '<select name="cfwc_rule_match_type" class="cfwc-rule-field cfwc-match-type" data-field="match_type" style="width: 100%; margin-bottom: 5px;">';
+        '<select name="cfwc_rule_match_type" class="cfwc-rule-field cfwc-rule-field--match-type cfwc-match-type" data-field="match_type">';
       newRowHtml += '<option value="all">All Products</option>';
       newRowHtml += '<option value="category">By Category</option>';
       newRowHtml += '<option value="hs_code">By HS Code</option>';
@@ -809,7 +712,7 @@
       newRowHtml += "</select>";
       // Category selector (hidden by default - only show for category/combined).
       newRowHtml +=
-        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-category-select wc-enhanced-select" data-field="category_ids" multiple="multiple" style="width: 100%; display: none; margin-bottom: 5px;" data-placeholder="Select categories...">';
+        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-rule-field--category cfwc-category-select wc-enhanced-select is-hidden" data-field="category_ids" multiple="multiple" data-placeholder="Select categories...">';
       if (cfwc_admin.categories) {
         $.each(cfwc_admin.categories, function (id, name) {
           newRowHtml += '<option value="' + id + '">' + name + "</option>";
@@ -817,14 +720,12 @@
       }
       newRowHtml += "</select>";
       // Add spacer between category and HS code fields.
-      newRowHtml +=
-        '<span class="cfwc-field-spacer" style="display: none; height: 5px; width: 100%;">&nbsp;</span>';
+      newRowHtml += '<span class="cfwc-field-spacer">&nbsp;</span>';
       // HS Code pattern input (hidden by default - only show for hs_code/combined).
       newRowHtml +=
-        '<input type="text" name="cfwc_rule_hs_code" class="cfwc-rule-field cfwc-hs-code" data-field="hs_code_pattern" placeholder="HS Code (e.g., 6109* or 61,62)" style="width: 100%; display: none;" />';
+        '<input type="text" name="cfwc_rule_hs_code" class="cfwc-rule-field cfwc-hs-code is-hidden" data-field="hs_code_pattern" placeholder="HS Code (e.g., 6109* or 61,62)" />';
       // Add required indicator (hidden by default, shows "Not required" by default).
-      newRowHtml +=
-        '<span class="cfwc-field-required" style="display: block; font-size: 11px; color: #999; margin-top: 2px;">Not required</span>';
+      newRowHtml += '<span class="cfwc-field-required">Not required</span>';
       newRowHtml += "</td>";
 
       // Type selector.
@@ -840,45 +741,44 @@
 
       // Rate/Amount input.
       newRowHtml +=
-        '<td><input type="number" name="cfwc_rule_rate" class="cfwc-rule-field" data-field="rate" value="0" step="0.01" style="width: 80px;" required />' +
-        '<span style="font-size: 11px; color: #999; display: block; margin-top: 2px;">Required *</span></td>';
+        '<td><input type="number" name="cfwc_rule_rate" class="cfwc-rule-field cfwc-rule-field--rate" data-field="rate" value="0" step="0.01" required />' +
+        '<span class="cfwc-field-required">Required *</span></td>';
 
       // Valuation method.
       newRowHtml += "<td>";
-      newRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
+      newRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method">';
       newRowHtml += '<option value="inherit">' + escapeHtml(strings.inherit_global || "Inherit global") + "</option>";
       newRowHtml += '<option value="fob">' + escapeHtml(strings.fob || "FOB") + "</option>";
       newRowHtml += '<option value="cif">' + escapeHtml(strings.cif || "CIF") + "</option>";
       newRowHtml += '<option value="cif_insurance">' + escapeHtml(strings.cif_insurance || "CIF + Insurance") + "</option>";
       newRowHtml += "</select>";
-      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">' + escapeHtml(strings.overrides_global_for_rule || "Overrides global for this rule") + "</span>";
+      newRowHtml += '<span class="cfwc-field-help">' + escapeHtml(strings.overrides_global_for_rule || "Overrides global for this rule") + "</span>";
       newRowHtml += "</td>";
 
       // Depends on (base_includes) - hidden for flat type.
       newRowHtml += '<td class="cfwc-base-includes-cell">';
-      newRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
+      newRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple">';
       newRowHtml += "</select>";
-      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">' + escapeHtml(strings.select_fees_include || "Select fees to include in base") + "</span>";
+      newRowHtml += '<span class="cfwc-field-help">' + escapeHtml(strings.select_fees_include || "Select fees to include in base") + "</span>";
       newRowHtml += "</td>";
 
       // Stacking mode.
       newRowHtml += "<td>";
       newRowHtml +=
-        '<select name="cfwc_rule_stacking" class="cfwc-rule-field cfwc-stacking-select" data-field="stacking_mode" style="width: 100%;">';
+        '<select name="cfwc_rule_stacking" class="cfwc-rule-field cfwc-stacking-select" data-field="stacking_mode">';
       newRowHtml += '<option value="add">Stack (Add to other fees)</option>';
       newRowHtml +=
         '<option value="override">Override (Replace lower priority)</option>';
       newRowHtml +=
         '<option value="exclusive">Exclusive (Only this fee)</option>';
       newRowHtml += "</select>";
+      newRowHtml += '<span class="description cfwc-stacking-help">';
       newRowHtml +=
-        '<span class="description" style="font-size: 11px; color: #666; margin-top: 5px; display: block;">';
+        '<span class="stacking-help-add is-visible">Adds with other matching rules</span>';
       newRowHtml +=
-        '<span class="stacking-help-add">Adds with other matching rules</span>';
+        '<span class="stacking-help-override">Replaces lower priority rules</span>';
       newRowHtml +=
-        '<span class="stacking-help-override" style="display: none;">Replaces lower priority rules</span>';
-      newRowHtml +=
-        '<span class="stacking-help-exclusive" style="display: none;">No other rules apply</span>';
+        '<span class="stacking-help-exclusive">No other rules apply</span>';
       newRowHtml += "</span>";
       newRowHtml += "</td>";
 
@@ -982,23 +882,23 @@
       // Label input with priority (first column).
       editRowHtml +=
         "<td>" +
-        '<input type="text" name="cfwc_rule_label" class="cfwc-rule-field" data-field="label" value="' +
+        '<input type="text" name="cfwc_rule_label" class="cfwc-rule-field cfwc-rule-field--label" data-field="label" value="' +
         (rule.label || "") +
         '" placeholder="' +
         (strings.fee_label || "Fee label") +
-        '" style="width: 100%; margin-bottom: 5px;" />' +
+        '" />' +
         '<input type="number" name="cfwc_rule_priority" class="cfwc-rule-field" data-field="priority" value="' +
         (rule.priority || 0) +
-        '" placeholder="Priority (0-100)" title="Higher priority rules are checked first (0-100)" style="width: 100%;" min="0" max="100" />' +
-        '<span style="font-size: 11px; color: #666; margin-top: 2px; display: inline-block;">Higher numbers = higher priority</span>' +
+        '" placeholder="Priority (0-100)" title="Higher priority rules are checked first (0-100)" min="0" max="100" />' +
+        '<span class="cfwc-field-help cfwc-field-help--inline">Higher numbers = higher priority</span>' +
         "</td>";
 
       // Countries column (From and To).
       editRowHtml += "<td>";
       editRowHtml +=
-        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select" data-field="from_country" data-placeholder="' +
+        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select" data-field="from_country" data-placeholder="' +
         (strings.from_country || "From (any)") +
-        '" style="width: 47%;">';
+        '">';
       editRowHtml +=
         '<option value="">Any Origin</option>' +
         getCountryOptions(
@@ -1006,12 +906,11 @@
         );
       editRowHtml += "</select>";
       // Add spacing between dropdowns.
+      editRowHtml += '<span class="cfwc-country-spacer">&nbsp;</span>';
       editRowHtml +=
-        '<span style="display: inline-block; width: 10px;">&nbsp;</span>';
-      editRowHtml +=
-        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select" data-field="to_country" data-placeholder="' +
+        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select" data-field="to_country" data-placeholder="' +
         (strings.to_country || "To (any)") +
-        '" style="width: 47%;">';
+        '">';
       editRowHtml +=
         '<option value="">Any Destination</option>' +
         getCountryOptions(rule.to_country || rule.country || "");
@@ -1020,7 +919,7 @@
       // Products column (Categories & HS Code).
       editRowHtml += "<td>";
       editRowHtml +=
-        '<select name="cfwc_rule_match_type" class="cfwc-rule-field cfwc-match-type" data-field="match_type" style="width: 100%; margin-bottom: 5px;">';
+        '<select name="cfwc_rule_match_type" class="cfwc-rule-field cfwc-rule-field--match-type cfwc-match-type" data-field="match_type">';
       editRowHtml +=
         '<option value="all"' +
         ((rule.match_type || "all") === "all" ? " selected" : "") +
@@ -1047,9 +946,9 @@
           ? "Select categories (optional)"
           : "Select categories...";
       editRowHtml +=
-        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-category-select wc-enhanced-select" data-field="category_ids" multiple="multiple" style="width: 100%; margin-bottom: 5px;' +
-        (showCategories ? "" : " display: none;") +
-        '" data-placeholder="' +
+        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-rule-field--category cfwc-category-select wc-enhanced-select' +
+        (showCategories ? "" : " is-hidden") +
+        '" data-field="category_ids" multiple="multiple" data-placeholder="' +
         categoryPlaceholder +
         '">';
       if (cfwc_admin.categories) {
@@ -1066,19 +965,19 @@
       var showSpacer =
         rule.match_type === "combined" || rule.match_type === "hs_code";
       editRowHtml +=
-        '<span class="cfwc-field-spacer" style="' +
-        (showSpacer ? "display: block;" : "display: none;") +
-        ' height: 5px; width: 100%;">&nbsp;</span>';
+        '<span class="cfwc-field-spacer' +
+        (showSpacer ? " is-visible" : "") +
+        '">&nbsp;</span>';
 
       // HS Code pattern input (show only for hs_code/combined).
       var showHsCode =
         rule.match_type === "hs_code" || rule.match_type === "combined";
       editRowHtml +=
-        '<input type="text" name="cfwc_rule_hs_code" class="cfwc-rule-field cfwc-hs-code" data-field="hs_code_pattern" value="' +
+        '<input type="text" name="cfwc_rule_hs_code" class="cfwc-rule-field cfwc-hs-code' +
+        (showHsCode ? "" : " is-hidden") +
+        '" data-field="hs_code_pattern" value="' +
         (rule.hs_code_pattern || "") +
-        '" placeholder="HS Code (e.g., 6109* or 61,62)" style="width: 100%;' +
-        (showHsCode ? "" : " display: none;") +
-        '"' +
+        '" placeholder="HS Code (e.g., 6109* or 61,62)"' +
         (showHsCode ? " required" : "") +
         " />";
       // Add required indicator with dynamic text based on match type.
@@ -1091,9 +990,7 @@
         requiredText = "Both required *";
       }
       editRowHtml +=
-        '<span class="cfwc-field-required" style="display: block; font-size: 11px; color: #999; margin-top: 2px;">' +
-        requiredText +
-        "</span>";
+        '<span class="cfwc-field-required">' + requiredText + "</span>";
       editRowHtml += "</td>";
 
       // Type selector.
@@ -1117,37 +1014,37 @@
       var rateField = rule.type === "percentage" ? "rate" : "amount";
       var rateValue = rule.type === "percentage" ? rule.rate : rule.amount;
       editRowHtml +=
-        '<td><input type="number" name="cfwc_rule_rate" class="cfwc-rule-field" data-field="' +
+        '<td><input type="number" name="cfwc_rule_rate" class="cfwc-rule-field cfwc-rule-field--rate" data-field="' +
         rateField +
         '" value="' +
         rateValue +
-        '" step="0.01" style="width: 80px;" required />' +
-        '<span style="font-size: 11px; color: #999; display: block; margin-top: 2px;">Required *</span></td>';
+        '" step="0.01" required />' +
+        '<span class="cfwc-field-required">Required *</span></td>';
 
       // Valuation method.
       var currentValuation = rule.valuation_method || "inherit";
       editRowHtml += "<td>";
-      editRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
+      editRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method">';
       editRowHtml += '<option value="inherit"' + (currentValuation === "inherit" ? " selected" : "") + ">" + escapeHtml(strings.inherit_global || "Inherit global") + "</option>";
       editRowHtml += '<option value="fob"' + (currentValuation === "fob" ? " selected" : "") + ">" + escapeHtml(strings.fob || "FOB") + "</option>";
       editRowHtml += '<option value="cif"' + (currentValuation === "cif" ? " selected" : "") + ">" + escapeHtml(strings.cif || "CIF") + "</option>";
       editRowHtml += '<option value="cif_insurance"' + (currentValuation === "cif_insurance" ? " selected" : "") + ">" + escapeHtml(strings.cif_insurance || "CIF + Insurance") + "</option>";
       editRowHtml += "</select>";
-      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">' + escapeHtml(strings.overrides_global_for_rule || "Overrides global for this rule") + "</span>";
+      editRowHtml += '<span class="cfwc-field-help">' + escapeHtml(strings.overrides_global_for_rule || "Overrides global for this rule") + "</span>";
       editRowHtml += "</td>";
 
       // Depends on (base_includes).
       var currentBaseIncludes = rule.base_includes || [];
       editRowHtml += '<td class="cfwc-base-includes-cell">';
-      editRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
+      editRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple">';
       editRowHtml += "</select>";
-      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">' + escapeHtml(strings.select_fees_include || "Select fees to include in base") + "</span>";
+      editRowHtml += '<span class="cfwc-field-help">' + escapeHtml(strings.select_fees_include || "Select fees to include in base") + "</span>";
       editRowHtml += "</td>";
 
       // Stacking mode.
       editRowHtml += "<td>";
       editRowHtml +=
-        '<select name="cfwc_rule_stacking" class="cfwc-rule-field cfwc-stacking-select" data-field="stacking_mode" style="width: 100%;">';
+        '<select name="cfwc_rule_stacking" class="cfwc-rule-field cfwc-stacking-select" data-field="stacking_mode">';
       editRowHtml +=
         '<option value="add"' +
         ((rule.stacking_mode || "add") === "add" ? " selected" : "") +
@@ -1161,20 +1058,19 @@
         (rule.stacking_mode === "exclusive" ? " selected" : "") +
         ">Exclusive (Only this fee)</option>";
       editRowHtml += "</select>";
-      editRowHtml +=
-        '<span class="description" style="font-size: 11px; color: #666; margin-top: 5px; display: block;">';
+      editRowHtml += '<span class="description cfwc-stacking-help">';
       var currentMode = rule.stacking_mode || "add";
       editRowHtml +=
-        '<span class="stacking-help-add" style="' +
-        (currentMode === "add" ? "" : "display: none;") +
+        '<span class="stacking-help-add' +
+        (currentMode === "add" ? " is-visible" : "") +
         '">Adds with other matching rules</span>';
       editRowHtml +=
-        '<span class="stacking-help-override" style="' +
-        (currentMode === "override" ? "" : "display: none;") +
+        '<span class="stacking-help-override' +
+        (currentMode === "override" ? " is-visible" : "") +
         '">Replaces lower priority rules</span>';
       editRowHtml +=
-        '<span class="stacking-help-exclusive" style="' +
-        (currentMode === "exclusive" ? "" : "display: none;") +
+        '<span class="stacking-help-exclusive' +
+        (currentMode === "exclusive" ? " is-visible" : "") +
         '">No other rules apply</span>';
       editRowHtml += "</span>";
       editRowHtml += "</td>";
@@ -1382,7 +1278,7 @@
       deleteClickDebounce[buttonId] = true;
 
       // Disable button temporarily to prevent double-clicks.
-      $button.prop("disabled", true).css("opacity", "0.5");
+      $button.prop("disabled", true);
 
       var rules = JSON.parse($("#cfwc_rules").val() || "[]");
 
@@ -1481,7 +1377,7 @@
       // Re-enable button after a short delay.
       setTimeout(function () {
         delete deleteClickDebounce[buttonId];
-        $button.prop("disabled", false).css("opacity", "1");
+        $button.prop("disabled", false);
       }, 300);
     });
 
@@ -1511,9 +1407,9 @@
           row += "<td>" + escapeHtml(rule.label || "");
           if (rule.priority && rule.priority > 0) {
             row +=
-              ' <span style="color: #666; font-size: 11px;">(' +
+              ' <span class="cfwc-priority-meta">(' +
               rule.priority +
-              ' <span class="dashicons dashicons-info" style="font-size: 14px; vertical-align: middle; cursor: help;" ' +
+              ' <span class="dashicons dashicons-info" ' +
               'title="Higher priority rules are checked first (0-100)"></span>)</span>';
           }
           row += "</td>";
@@ -1567,7 +1463,7 @@
               }
               if (catNames.length > 0) {
                 criteria.push(
-                  '<span class="dashicons dashicons-category" style="font-size: 14px;"></span> ' +
+                  '<span class="dashicons dashicons-category cfwc-criteria-icon"></span> ' +
                     catNames.join(", ")
                 );
               }
@@ -1576,7 +1472,7 @@
             // HS Code.
             if (rule.hs_code_pattern) {
               criteria.push(
-                '<span class="dashicons dashicons-tag" style="font-size: 14px;"></span> HS: ' +
+                '<span class="dashicons dashicons-tag cfwc-criteria-icon"></span> HS: ' +
                   rule.hs_code_pattern
               );
             }
@@ -1611,9 +1507,9 @@
             cif_insurance: strings.cif_insurance_short || "CIF + Ins",
           };
           if (valuationMethod !== "inherit") {
-            row += '<td><span style="display: inline-block; padding: 3px 8px; background: #2271b1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' + escapeHtml(strings.overrides_global || "Overrides global valuation") + '">' + escapeHtml(valuationLabels[valuationMethod] || valuationMethod) + "</span></td>";
+            row += '<td><span class="cfwc-rule-badge cfwc-rule-badge--valuation" title="' + escapeHtml(strings.overrides_global || "Overrides global valuation") + '">' + escapeHtml(valuationLabels[valuationMethod] || valuationMethod) + "</span></td>";
           } else {
-            row += '<td><em style="color: #999; font-size: 11px;">' + escapeHtml(strings.global_label || "Global") + "</em></td>";
+            row += '<td><em class="cfwc-empty-cell">' + escapeHtml(strings.global_label || "Global") + "</em></td>";
           }
 
           // Depends on (base_includes).
@@ -1635,9 +1531,9 @@
               ? (strings.dep_fee_singular || "+%d fee")
               : (strings.dep_fee_plural || "+%d fees");
             var depBadgeText = depTemplate.replace("%d", baseIncludes.length);
-            row += '<td><span style="display: inline-block; padding: 3px 8px; background: #8261a1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' + depTitle + '">' + escapeHtml(depBadgeText) + "</span></td>";
+            row += '<td><span class="cfwc-rule-badge cfwc-rule-badge--dependency" title="' + depTitle + '">' + escapeHtml(depBadgeText) + "</span></td>";
           } else {
-            row += '<td><em style="color: #999; font-size: 11px;">-</em></td>';
+            row += '<td><em class="cfwc-empty-cell">-</em></td>';
           }
 
           // Stacking mode - Use WooCommerce-style badges to match PHP rendering.
@@ -1647,11 +1543,6 @@
             override: strings.override || "Override",
             exclusive: strings.exclusive || "Exclusive",
           };
-          var stackingColors = {
-            add: "#46b450",
-            override: "#f0ad4e",
-            exclusive: "#dc3232",
-          };
           var stackingDescriptions = {
             add: strings.stack_desc || "Adds with other matching rules",
             override: strings.override_desc || "Replaces lower priority rules",
@@ -1659,17 +1550,16 @@
           };
 
           // Get values with defaults.
-          var badgeColor = stackingColors[stackingMode] || stackingColors.add;
-          var badgeLabel = stackingLabels[stackingMode] || stackingLabels.add;
-          var badgeTitle =
-            stackingDescriptions[stackingMode] || stackingDescriptions.add;
+          var modeKey = stackingLabels[stackingMode] ? stackingMode : "add";
+          var badgeLabel = stackingLabels[modeKey];
+          var badgeTitle = stackingDescriptions[modeKey];
 
           // Render WooCommerce-style badge matching PHP output.
           row +=
             "<td>" +
-            '<span style="display: inline-block; padding: 3px 8px; background: ' +
-            badgeColor +
-            '; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' +
+            '<span class="cfwc-rule-badge cfwc-rule-badge--stacking-' +
+            modeKey +
+            '" title="' +
             badgeTitle +
             '">' +
             badgeLabel +

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -846,19 +846,19 @@
       // Valuation method.
       newRowHtml += "<td>";
       newRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
-      newRowHtml += '<option value="inherit">Inherit global</option>';
-      newRowHtml += '<option value="fob">FOB</option>';
-      newRowHtml += '<option value="cif">CIF</option>';
-      newRowHtml += '<option value="cif_insurance">CIF + Insurance</option>';
+      newRowHtml += '<option value="inherit">' + escapeHtml(strings.inherit_global || "Inherit global") + "</option>";
+      newRowHtml += '<option value="fob">' + escapeHtml(strings.fob || "FOB") + "</option>";
+      newRowHtml += '<option value="cif">' + escapeHtml(strings.cif || "CIF") + "</option>";
+      newRowHtml += '<option value="cif_insurance">' + escapeHtml(strings.cif_insurance || "CIF + Insurance") + "</option>";
       newRowHtml += "</select>";
-      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Overrides global for this rule</span>';
+      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">' + escapeHtml(strings.overrides_global_for_rule || "Overrides global for this rule") + "</span>";
       newRowHtml += "</td>";
 
       // Depends on (base_includes) - hidden for flat type.
       newRowHtml += '<td class="cfwc-base-includes-cell">';
       newRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
       newRowHtml += "</select>";
-      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Select fees to include in base</span>';
+      newRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">' + escapeHtml(strings.select_fees_include || "Select fees to include in base") + "</span>";
       newRowHtml += "</td>";
 
       // Stacking mode.
@@ -914,10 +914,11 @@
           ".cfwc-rules-table tbody tr:last .cfwc-base-includes-select"
         );
         populateBaseIncludesSelect($baseIncludes, newRuleId, []);
+        var basePlaceholder = strings.select_fees_include || "Select fees to include in base";
         if ($baseIncludes.length && typeof $.fn.selectWoo !== "undefined") {
-          $baseIncludes.selectWoo({ width: "100%", placeholder: "Select fees to include in base" });
+          $baseIncludes.selectWoo({ width: "100%", placeholder: basePlaceholder });
         } else if ($baseIncludes.length && $.fn.select2) {
-          $baseIncludes.select2({ width: "100%", placeholder: "Select fees to include in base" });
+          $baseIncludes.select2({ width: "100%", placeholder: basePlaceholder });
         }
       }, 100);
 
@@ -1127,12 +1128,12 @@
       var currentValuation = rule.valuation_method || "inherit";
       editRowHtml += "<td>";
       editRowHtml += '<select name="cfwc_rule_valuation_method" class="cfwc-rule-field" data-field="valuation_method" style="width: 100%;">';
-      editRowHtml += '<option value="inherit"' + (currentValuation === "inherit" ? " selected" : "") + '>Inherit global</option>';
-      editRowHtml += '<option value="fob"' + (currentValuation === "fob" ? " selected" : "") + '>FOB</option>';
-      editRowHtml += '<option value="cif"' + (currentValuation === "cif" ? " selected" : "") + '>CIF</option>';
-      editRowHtml += '<option value="cif_insurance"' + (currentValuation === "cif_insurance" ? " selected" : "") + '>CIF + Insurance</option>';
+      editRowHtml += '<option value="inherit"' + (currentValuation === "inherit" ? " selected" : "") + ">" + escapeHtml(strings.inherit_global || "Inherit global") + "</option>";
+      editRowHtml += '<option value="fob"' + (currentValuation === "fob" ? " selected" : "") + ">" + escapeHtml(strings.fob || "FOB") + "</option>";
+      editRowHtml += '<option value="cif"' + (currentValuation === "cif" ? " selected" : "") + ">" + escapeHtml(strings.cif || "CIF") + "</option>";
+      editRowHtml += '<option value="cif_insurance"' + (currentValuation === "cif_insurance" ? " selected" : "") + ">" + escapeHtml(strings.cif_insurance || "CIF + Insurance") + "</option>";
       editRowHtml += "</select>";
-      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Overrides global for this rule</span>';
+      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">' + escapeHtml(strings.overrides_global_for_rule || "Overrides global for this rule") + "</span>";
       editRowHtml += "</td>";
 
       // Depends on (base_includes).
@@ -1140,7 +1141,7 @@
       editRowHtml += '<td class="cfwc-base-includes-cell">';
       editRowHtml += '<select name="cfwc_rule_base_includes" class="cfwc-rule-field cfwc-base-includes-select" data-field="base_includes" multiple="multiple" style="width: 100%;">';
       editRowHtml += "</select>";
-      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">Select fees to include in base</span>';
+      editRowHtml += '<span style="font-size: 11px; color: #666; margin-top: 2px; display: block;">' + escapeHtml(strings.select_fees_include || "Select fees to include in base") + "</span>";
       editRowHtml += "</td>";
 
       // Stacking mode.
@@ -1206,15 +1207,16 @@
         rule.rule_id || "",
         currentBaseIncludes
       );
+      var editBasePlaceholder = strings.select_fees_include || "Select fees to include in base";
       if ($baseIncludes.length && typeof $.fn.selectWoo !== "undefined") {
         $baseIncludes.selectWoo({
           width: "100%",
-          placeholder: "Select fees to include in base",
+          placeholder: editBasePlaceholder,
         });
       } else if ($baseIncludes.length && $.fn.select2) {
         $baseIncludes.select2({
           width: "100%",
-          placeholder: "Select fees to include in base",
+          placeholder: editBasePlaceholder,
         });
       }
 
@@ -1604,14 +1606,14 @@
           // Valuation method badge.
           var valuationMethod = rule.valuation_method || "inherit";
           var valuationLabels = {
-            fob: "FOB",
-            cif: "CIF",
-            cif_insurance: "CIF + Ins",
+            fob: strings.fob || "FOB",
+            cif: strings.cif || "CIF",
+            cif_insurance: strings.cif_insurance_short || "CIF + Ins",
           };
           if (valuationMethod !== "inherit") {
-            row += '<td><span style="display: inline-block; padding: 3px 8px; background: #2271b1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="Overrides global valuation">' + escapeHtml(valuationLabels[valuationMethod] || valuationMethod) + "</span></td>";
+            row += '<td><span style="display: inline-block; padding: 3px 8px; background: #2271b1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' + escapeHtml(strings.overrides_global || "Overrides global valuation") + '">' + escapeHtml(valuationLabels[valuationMethod] || valuationMethod) + "</span></td>";
           } else {
-            row += '<td><em style="color: #999; font-size: 11px;">Global</em></td>';
+            row += '<td><em style="color: #999; font-size: 11px;">' + escapeHtml(strings.global_label || "Global") + "</em></td>";
           }
 
           // Depends on (base_includes).
@@ -1627,7 +1629,13 @@
               });
             });
             var depTitle = escapeHtml(depLabels.join(", "));
-            row += '<td><span style="display: inline-block; padding: 3px 8px; background: #8261a1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' + depTitle + '">+' + baseIncludes.length + " fee(s)</span></td>";
+            // Pick singular/plural form. Languages with >2 plural forms (e.g. Russian, Polish, Arabic)
+            // need wp.i18n._n with wp_set_script_translations; tracked separately.
+            var depTemplate = baseIncludes.length === 1
+              ? (strings.dep_fee_singular || "+%d fee")
+              : (strings.dep_fee_plural || "+%d fees");
+            var depBadgeText = depTemplate.replace("%d", baseIncludes.length);
+            row += '<td><span style="display: inline-block; padding: 3px 8px; background: #8261a1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' + depTitle + '">' + escapeHtml(depBadgeText) + "</span></td>";
           } else {
             row += '<td><em style="color: #999; font-size: 11px;">-</em></td>';
           }

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -109,7 +109,6 @@
       var $categorySelect = $row.find(".cfwc-category-select");
       var $hsCodeInput = $row.find(".cfwc-hs-code");
       var $requiredIndicator = $row.find(".cfwc-field-required");
-      var $spacer = $row.find(".cfwc-field-spacer");
 
       // Show fields based on match type.
       // Note: addClass/removeClass("is-hidden") manages the initial render's class;
@@ -119,7 +118,6 @@
         // All Products - hide both category and HS code fields, show "Not required".
         $categorySelect.addClass("is-hidden").hide().removeAttr("required");
         $hsCodeInput.addClass("is-hidden").hide().removeAttr("required");
-        $spacer.removeClass("is-visible");
         $requiredIndicator.show().html("Not required");
         $categorySelect.attr("data-placeholder", "Select categories...");
         $hsCodeInput.attr("placeholder", "HS Code (e.g., 6109* or 61,62)");
@@ -127,14 +125,12 @@
         // By Category - show only category field, hide HS code.
         $categorySelect.removeClass("is-hidden").show().attr("required", "required");
         $hsCodeInput.addClass("is-hidden").hide().removeAttr("required");
-        $spacer.removeClass("is-visible");
         $requiredIndicator.show().html("Required *");
         $categorySelect.attr("data-placeholder", "Select categories...");
         $hsCodeInput.attr("placeholder", "HS Code (e.g., 6109* or 61,62)");
       } else if (matchType === "hs_code") {
         // By HS Code - show both fields but category is not required.
         $categorySelect.removeClass("is-hidden").show().removeAttr("required");
-        $spacer.addClass("is-visible"); // Show spacer between fields.
         $hsCodeInput.removeClass("is-hidden").show().attr("required", "required");
         $requiredIndicator
           .show()
@@ -145,9 +141,8 @@
         );
         $hsCodeInput.attr("placeholder", "HS Code (e.g., 6109* or 61,62)");
       } else if (matchType === "combined") {
-        // Category + HS Code - show both fields with spacing.
+        // Category + HS Code - show both fields.
         $categorySelect.removeClass("is-hidden").show().attr("required", "required");
-        $spacer.addClass("is-visible"); // Show spacer between fields.
         $hsCodeInput.removeClass("is-hidden").show().attr("required", "required");
         $requiredIndicator.show().html("Both required *");
         $categorySelect.attr("data-placeholder", "Select categories...");
@@ -691,8 +686,6 @@
       newRowHtml +=
         '<option value="">Any Origin</option>' + getCountryOptions("");
       newRowHtml += "</select>";
-      // Add spacing between dropdowns.
-      newRowHtml += '<span class="cfwc-country-spacer">&nbsp;</span>';
       newRowHtml +=
         '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="to_country" data-placeholder="' +
         (strings.to_country || "To (any)") +
@@ -719,8 +712,6 @@
         });
       }
       newRowHtml += "</select>";
-      // Add spacer between category and HS code fields.
-      newRowHtml += '<span class="cfwc-field-spacer">&nbsp;</span>';
       // HS Code pattern input (hidden by default - only show for hs_code/combined).
       newRowHtml +=
         '<input type="text" name="cfwc_rule_hs_code" class="cfwc-rule-field cfwc-hs-code is-hidden" data-field="hs_code_pattern" placeholder="HS Code (e.g., 6109* or 61,62)" />';
@@ -905,8 +896,6 @@
           rule.from_country || rule.origin_country || rule.country || ""
         );
       editRowHtml += "</select>";
-      // Add spacing between dropdowns.
-      editRowHtml += '<span class="cfwc-country-spacer">&nbsp;</span>';
       editRowHtml +=
         '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="to_country" data-placeholder="' +
         (strings.to_country || "To (any)") +
@@ -960,14 +949,6 @@
         });
       }
       editRowHtml += "</select>";
-
-      // Add spacer between category and HS code fields.
-      var showSpacer =
-        rule.match_type === "combined" || rule.match_type === "hs_code";
-      editRowHtml +=
-        '<span class="cfwc-field-spacer' +
-        (showSpacer ? " is-visible" : "") +
-        '">&nbsp;</span>';
 
       // HS Code pattern input (show only for hs_code/combined).
       var showHsCode =

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1382,7 +1382,7 @@
         // Has rules - show "Add to Existing Rules".
         addPresetBtn.text(strings.add_to_existing || "Add to Existing Rules");
         $.each(rules, function (index, rule) {
-          var row = "<tr>";
+          var row = '<tr class="cfwc-rule-row">';
 
           // Label with priority (first column).
           row += "<td>" + escapeHtml(rule.label || "");

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -685,7 +685,7 @@
       // Countries column (From and To).
       newRowHtml += "<td>";
       newRowHtml +=
-        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select" data-field="from_country" data-placeholder="' +
+        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="from_country" data-placeholder="' +
         (strings.from_country || "From (any)") +
         '">';
       newRowHtml +=
@@ -694,7 +694,7 @@
       // Add spacing between dropdowns.
       newRowHtml += '<span class="cfwc-country-spacer">&nbsp;</span>';
       newRowHtml +=
-        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select" data-field="to_country" data-placeholder="' +
+        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="to_country" data-placeholder="' +
         (strings.to_country || "To (any)") +
         '">';
       newRowHtml +=
@@ -712,7 +712,7 @@
       newRowHtml += "</select>";
       // Category selector (hidden by default - only show for category/combined).
       newRowHtml +=
-        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-rule-field--category cfwc-category-select wc-enhanced-select is-hidden" data-field="category_ids" multiple="multiple" data-placeholder="Select categories...">';
+        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-rule-field--category cfwc-category-select wc-enhanced-select cfwc-select2-field is-hidden" data-field="category_ids" multiple="multiple" data-placeholder="Select categories...">';
       if (cfwc_admin.categories) {
         $.each(cfwc_admin.categories, function (id, name) {
           newRowHtml += '<option value="' + id + '">' + name + "</option>";
@@ -896,7 +896,7 @@
       // Countries column (From and To).
       editRowHtml += "<td>";
       editRowHtml +=
-        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select" data-field="from_country" data-placeholder="' +
+        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="from_country" data-placeholder="' +
         (strings.from_country || "From (any)") +
         '">';
       editRowHtml +=
@@ -908,7 +908,7 @@
       // Add spacing between dropdowns.
       editRowHtml += '<span class="cfwc-country-spacer">&nbsp;</span>';
       editRowHtml +=
-        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select" data-field="to_country" data-placeholder="' +
+        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="to_country" data-placeholder="' +
         (strings.to_country || "To (any)") +
         '">';
       editRowHtml +=
@@ -946,7 +946,7 @@
           ? "Select categories (optional)"
           : "Select categories...";
       editRowHtml +=
-        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-rule-field--category cfwc-category-select wc-enhanced-select' +
+        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-rule-field--category cfwc-category-select wc-enhanced-select cfwc-select2-field' +
         (showCategories ? "" : " is-hidden") +
         '" data-field="category_ids" multiple="multiple" data-placeholder="' +
         categoryPlaceholder +

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,12 @@
 *** Customs Fees for WooCommerce Changelog ***
 
 2026-04-13 - version 1.1.7
+* Add - Per-rule valuation method override (FOB, CIF, CIF + Insurance) with inheritance from global setting.
+* Add - Compound base support via base_includes: rules can include other rules' computed fees in their customs value.
+* Add - Round-based dependency resolution with cycle detection for base_includes.
+* Add - Admin UI columns for Valuation and Depends On in the rules table.
+* Update - Canada, Australia, New Zealand, UK, and EU presets use correct duty vs. import tax valuation bases.
+* Update - CSV export/import preserves rule_id, valuation_method, base_includes, and all advanced rule fields.
 * Tweak - WooCommerce 10.7 Compatibility.
 
 2026-03-31 - version 1.1.6

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,14 @@
 *** Customs Fees for WooCommerce Changelog ***
 
-2026-04-13 - version 1.1.7
+= 1.2.0 - 2026-xx-xx =
 * Add - Per-rule valuation method override (FOB, CIF, CIF + Insurance) with inheritance from global setting.
 * Add - Compound base support via base_includes: rules can include other rules' computed fees in their customs value.
 * Add - Round-based dependency resolution with cycle detection for base_includes.
 * Add - Admin UI columns for Valuation and Depends On in the rules table.
 * Update - Canada, Australia, New Zealand, UK, and EU presets use correct duty vs. import tax valuation bases.
 * Update - CSV export/import preserves rule_id, valuation_method, base_includes, and all advanced rule fields.
+
+2026-04-13 - version 1.1.7
 * Tweak - WooCommerce 10.7 Compatibility.
 
 2026-03-31 - version 1.1.6

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,12 +1,8 @@
 *** Customs Fees for WooCommerce Changelog ***
 
-= 1.2.0 - 2026-xx-xx =
-* Add - Per-rule valuation method override (FOB, CIF, CIF + Insurance) with inheritance from global setting.
-* Add - Compound base support via base_includes: rules can include other rules' computed fees in their customs value.
-* Add - Round-based dependency resolution with cycle detection for base_includes.
-* Add - Admin UI columns for Valuation and Depends On in the rules table.
-* Update - Canada, Australia, New Zealand, UK, and EU presets use correct duty vs. import tax valuation bases.
-* Update - CSV export/import preserves rule_id, valuation_method, base_includes, and all advanced rule fields.
+2026-xx-xx - version 1.2.0
+* Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
+* Update - Built-in presets for Canada, Australia, New Zealand, UK, and EU now use correct duty vs. import tax valuation bases.
 
 2026-04-13 - version 1.1.7
 * Tweak - WooCommerce 10.7 Compatibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2026-xx-xx - version 1.2.0
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
 * Update - Built-in presets for Canada, Australia, New Zealand, UK, and EU now use correct duty vs. import tax valuation bases.
+* Dev    - `cfwc_customs_value` filter now passes the matching rule as a 5th argument; existing 4-argument callbacks remain backwards-compatible.
 * Tweak  - WooCommerce 10.8 Compatibility.
 
 2026-04-13 - version 1.1.7

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,8 @@
             "composer.lock",
             "node_modules",
             "customs-fees-for-woocommerce.zip",
+            "phpunit.xml",
+            "phpunit.xml.dist",
             ".*",
             "AGENTS.md",
             "CLAUDE.md"
@@ -30,11 +32,23 @@
         "szepeviktor/phpstan-wordpress": "*",
         "phpstan/phpstan": "*",
         "phpstan/extension-installer": "*",
-        "php-stubs/woocommerce-stubs": "^10.1"
+        "php-stubs/woocommerce-stubs": "^10.1",
+        "phpunit/phpunit": "^9.6",
+        "yoast/phpunit-polyfills": "^2.0"
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "WooCommerce\\CustomsFees\\Tests\\": "tests/"
+        }
     },
     "config": {
         "allow-plugins": {
             "phpstan/extension-installer": true
         }
+    },
+    "scripts": {
+        "test": [
+            "bash tests/bin/run-tests.sh"
+        ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,327 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "33f60ced67a89093afd52d3c100f29e5",
+    "content-hash": "0a439e6654d19d91db18ec64008f5993",
     "packages": [],
     "packages-dev": [
         {
-            "name": "php-stubs/woocommerce-stubs",
-            "version": "v10.1.1",
+            "name": "doctrine/instantiator",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/php-stubs/woocommerce-stubs.git",
-                "reference": "b8e010db32f6a5876f0c49fda467e15ea5d6f97f"
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/b8e010db32f6a5876f0c49fda467e15ea5d6f97f",
-                "reference": "b8e010db32f6a5876f0c49fda467e15ea5d6f97f",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/phpstan": "^1.9.4",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpunit/phpunit": "^9.5.27",
+                "vimeo/psalm": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:23:10+00:00"
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "php-stubs/woocommerce-stubs",
+            "version": "v10.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-stubs/woocommerce-stubs.git",
+                "reference": "7251902ebc048626aff04855c333afa9f3bae2d5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-stubs/woocommerce-stubs/zipball/7251902ebc048626aff04855c333afa9f3bae2d5",
+                "reference": "7251902ebc048626aff04855c333afa9f3bae2d5",
                 "shasum": ""
             },
             "require": {
@@ -47,22 +353,22 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/woocommerce-stubs/issues",
-                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.1.1"
+                "source": "https://github.com/php-stubs/woocommerce-stubs/tree/v10.7.0"
             },
-            "time": "2025-08-20T15:58:51+00:00"
+            "time": "2026-04-14T15:19:28+00:00"
         },
         {
             "name": "php-stubs/wordpress-stubs",
-            "version": "v6.8.2",
+            "version": "v6.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-stubs/wordpress-stubs.git",
-                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8"
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
-                "reference": "9c8e22e437463197c1ec0d5eaa9ddd4a0eb6d7f8",
+                "url": "https://api.github.com/repos/php-stubs/wordpress-stubs/zipball/90a9412826b9944f93b10bf41d795b5fe68abcd5",
+                "reference": "90a9412826b9944f93b10bf41d795b5fe68abcd5",
                 "shasum": ""
             },
             "conflict": {
@@ -72,10 +378,11 @@
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "nikic/php-parser": "^5.5",
                 "php": "^7.4 || ^8.0",
-                "php-stubs/generator": "^0.8.3",
-                "phpdocumentor/reflection-docblock": "^5.4.1",
+                "php-stubs/generator": "^0.8.6",
+                "phpdocumentor/reflection-docblock": "^6.0",
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^9.5",
+                "symfony/polyfill-php80": "*",
                 "szepeviktor/phpcs-psr-12-neutron-hybrid-ruleset": "^1.1.1",
                 "wp-coding-standards/wpcs": "3.1.0 as 2.3.0"
             },
@@ -98,9 +405,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-stubs/wordpress-stubs/issues",
-                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.8.2"
+                "source": "https://github.com/php-stubs/wordpress-stubs/tree/v6.9.4"
             },
-            "time": "2025-07-16T06:41:00+00:00"
+            "time": "2026-05-01T20:36:01+00:00"
         },
         {
             "name": "phpstan/extension-installer",
@@ -152,16 +459,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.22",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4"
-            },
+            "version": "2.1.55",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/41600c8379eb5aee63e9413fe9e97273e25d57e4",
-                "reference": "41600c8379eb5aee63e9413fe9e97273e25d57e4",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/9eaac3826ed5e9b8427350a43cac825eeca3f566",
+                "reference": "9eaac3826ed5e9b8427350a43cac825eeca3f566",
                 "shasum": ""
             },
             "require": {
@@ -206,20 +508,1461 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-04T19:17:37+00:00"
+            "time": "2026-05-18T11:57:34+00:00"
         },
         {
-            "name": "szepeviktor/phpstan-wordpress",
-            "version": "v2.0.2",
+            "name": "phpunit/php-code-coverage",
+            "version": "9.2.32",
             "source": {
                 "type": "git",
-                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
-                "reference": "963887b04c21fe7ac78e61c1351f8b00fff9f8f8"
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/963887b04c21fe7ac78e61c1351f8b00fff9f8f8",
-                "reference": "963887b04c21fe7ac78e61c1351f8b00fff9f8f8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "reference": "85402a822d1ecf1db1096959413d35e1c37cf1a5",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=7.3",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-text-template": "^2.0.4",
+                "sebastian/code-unit-reverse-lookup": "^2.0.3",
+                "sebastian/complexity": "^2.0.3",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/lines-of-code": "^1.0.4",
+                "sebastian/version": "^3.0.2",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.2.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.32"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:23:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "3.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "reference": "cf1c2e7c203ac650e352f4cc675a7021e7d1b3cf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-12-02T12:48:52+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "reference": "5a10147d0aaf65b58940a0b72f71c9ac0423cc67",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:58:55+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "reference": "5da5f67fc95621df9ff4c4e5a84d6a8a2acf7c28",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T05:33:50+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "5.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "reference": "5a63ce20ed1b5bf577850e2c4e87f4aa902afbd2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:16:10+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "9.6.34",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b36f02317466907a230d3aa1d34467041271ef4a",
+                "reference": "b36f02317466907a230d3aa1d34467041271ef4a",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.5.0 || ^2",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=7.3",
+                "phpunit/php-code-coverage": "^9.2.32",
+                "phpunit/php-file-iterator": "^3.0.6",
+                "phpunit/php-invoker": "^3.1.1",
+                "phpunit/php-text-template": "^2.0.4",
+                "phpunit/php-timer": "^5.0.3",
+                "sebastian/cli-parser": "^1.0.2",
+                "sebastian/code-unit": "^1.0.8",
+                "sebastian/comparator": "^4.0.10",
+                "sebastian/diff": "^4.0.6",
+                "sebastian/environment": "^5.1.5",
+                "sebastian/exporter": "^4.0.8",
+                "sebastian/global-state": "^5.0.8",
+                "sebastian/object-enumerator": "^4.0.4",
+                "sebastian/resource-operations": "^3.0.4",
+                "sebastian/type": "^3.2.1",
+                "sebastian/version": "^3.0.2"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "9.6-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.6.34"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-27T05:45:00+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "reference": "2b56bea83a09de3ac06bb18b92f068e60cc6f50b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:27:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "reference": "1fc9f64c0927627ef78ba436c9b17d967e68e120",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:08:54+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "reference": "ac91f01ccec49fb77bdc6fd1e548bc70f7faa3e5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T05:30:19+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "4.0.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "reference": "e4df00b9b3571187db2831ae9aada2c6efbd715d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/diff": "^4.0",
+                "sebastian/exporter": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.10"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:22:56+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "reference": "25f207c40d62b8b7aa32f5ab026c53561964053a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:19:30+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "reference": "ba01945089c3a293b01ba9badc29ad55b106b0bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T06:30:58+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "reference": "830c43a844f1f8d5b7a1f6d6076b784454d8b7ed",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "http://www.github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:03:51+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "4.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "reference": "14c6ba52f95a36c3d27c835d65efc7123c446e8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:03:27+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "5.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "reference": "b6781316bdcd28260904e7cc18ec983d0d2ef4f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^9.3"
+            },
+            "suggest": {
+                "ext-uopz": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "http://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:10:35+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "1.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "reference": "e1e4a170560925c26d424b6a03aed157e7dcc5c5",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-22T06:20:34+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/5c9eeac41b290a3712d88851518825ad78f45c71",
+                "reference": "5c9eeac41b290a3712d88851518825ad78f45c71",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3",
+                "sebastian/object-reflector": "^2.0",
+                "sebastian/recursion-context": "^4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:12:34+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "reference": "b4f479ebdbf63ac605d183ece17d8d7fe49c15c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-10-26T13:14:26+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "4.0.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/539c6691e0623af6dc6f9c20384c120f963465a0",
+                "reference": "539c6691e0623af6dc6f9c20384c120f963465a0",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.6"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T06:57:39+00:00"
+        },
+        {
+            "name": "sebastian/resource-operations",
+            "version": "3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "reference": "05d5692a7993ecccd56a03e40cd7e5b09b1d404e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-14T16:00:52+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "reference": "75e2c2a32f5e0b3aef905b9ed0b179b953b3d7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/3.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:13:03+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c6c1022351a901512170118436c764e473f6de8c",
+                "reference": "c6c1022351a901512170118436c764e473f6de8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-09-28T06:39:44+00:00"
+        },
+        {
+            "name": "szepeviktor/phpstan-wordpress",
+            "version": "v2.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/szepeviktor/phpstan-wordpress.git",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/szepeviktor/phpstan-wordpress/zipball/aa722f037b2d034828cd6c55ebe9e5c74961927e",
+                "reference": "aa722f037b2d034828cd6c55ebe9e5c74961927e",
                 "shasum": ""
             },
             "require": {
@@ -229,6 +1972,7 @@
             },
             "require-dev": {
                 "composer/composer": "^2.1.14",
+                "composer/semver": "^3.4",
                 "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
                 "php-parallel-lint/php-parallel-lint": "^1.1",
                 "phpstan/phpstan-strict-rules": "^2.0",
@@ -266,9 +2010,122 @@
             ],
             "support": {
                 "issues": "https://github.com/szepeviktor/phpstan-wordpress/issues",
-                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.2"
+                "source": "https://github.com/szepeviktor/phpstan-wordpress/tree/v2.0.3"
             },
-            "time": "2025-02-12T18:43:37+00:00"
+            "time": "2025-09-14T02:58:22+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "2.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "reference": "1a6aecc9ebe4a9cea4e1047d0e6c496e52314c27",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6",
+                "phpunit/phpunit": "^5.7.21 || ^6.0 || ^7.0 || ^8.0 || ^9.0 || ^10.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-08-10T05:13:49+00:00"
         }
     ],
     "aliases": [],
@@ -278,5 +2135,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/docs/CIF.md
+++ b/docs/CIF.md
@@ -1,6 +1,6 @@
 # CIF Customs Valuation Documentation
 
-This document covers the CIF (Cost, Insurance, Freight) customs valuation feature added in version 1.1.4.
+This document covers the CIF (Cost, Insurance, Freight) customs valuation feature added in version 1.1.4, and the per-rule valuation & compound bases feature added in version 1.2.0.
 
 ---
 
@@ -59,6 +59,74 @@ Customs Value (A) = $100 + ($20 × 50%) = $110
 Customs Value (B) = $100 + ($20 × 50%) = $110
 Total Customs Fee = ($110 + $110) × 25% = $55.00
 ```
+
+---
+
+## Per-Rule Valuation & Compound Bases (v1.2.0)
+
+Version 1.2.0 adds per-rule valuation method overrides and compound base support, allowing different valuation methods for duty vs. import tax within the same country.
+
+### Problem: Single Global Setting is Insufficient
+
+Some jurisdictions require different valuation bases for duty vs. import tax:
+
+- **Canada**: Duty on FOB, GST on CIF + duty amount
+- **Australia**: Duty on FOB, GST on customs value + duty
+- **UK/EU**: Duty on CIF, VAT on CIF + duty
+
+A single global FOB/CIF toggle cannot produce compliant results for these countries.
+
+### Per-Rule Valuation Method
+
+Each rule can now override the global valuation method:
+
+| Setting | Behavior |
+|---------|----------|
+| `inherit` | Use the global setting (default) |
+| `fob` | Product value only |
+| `cif` | Product value + shipping |
+| `cif_insurance` | Product value + shipping + insurance |
+
+**Admin UI:** Each rule has a "Valuation" column showing the override (or "Global" if inheriting).
+
+### Compound Bases (`base_includes`)
+
+A rule can include other rules' computed fees in its own customs value base. This enables GST-on-CIF+duty calculations.
+
+**Example - Canada:**
+
+| Rule | Rate | Valuation | Depends on |
+|------|------|-----------|------------|
+| Duty | 8% | FOB | - |
+| GST | 5% | CIF | Duty |
+
+**Calculation:**
+- Product: $100, Shipping: $20
+- Duty base = $100 (FOB)
+- Duty = $100 × 8% = **$8.00**
+- GST base = $120 (CIF) + $8.00 (duty) = **$128.00**
+- GST = $128 × 5% = **$6.40**
+
+### Dependency Resolution
+
+The calculator resolves rule dependencies in rounds:
+
+1. Base rules (no dependencies) calculate first
+2. Dependent rules calculate after their dependencies
+3. Cycles are detected and logged; offending rules fall back to their own base
+
+### Admin UI
+
+- **Add/Edit Rule Modal**: New "Valuation" select and "Depends on" multi-select
+- **Rules Table**: Shows valuation badge and dependency count
+- **Cycle Warning**: Dismissible admin notice appears if a cycle is detected
+
+### Migration
+
+Existing rules from versions < 1.2.0 are automatically migrated on upgrade:
+- `rule_id`: Assigned a stable UUID
+- `valuation_method`: Set to `inherit`
+- `base_includes`: Set to empty array
 
 ### Important Notes
 

--- a/docs/CIF.md
+++ b/docs/CIF.md
@@ -213,7 +213,7 @@ apply_filters( 'cfwc_fee_tax_class_default', '', $rule );
 apply_filters( 'cfwc_product_origin', $origin, $product_id, $product );
 
 // Modify the customs value (for CIF calculations)
-apply_filters( 'cfwc_customs_value', $customs_value, $line_total, $cart_item, $method );
+apply_filters( 'cfwc_customs_value', $customs_value, $line_total, $cart_item, $method, $rule );
 
 // Provide insurance value for CIF calculations
 apply_filters( 'cfwc_insurance_value', $insurance_value, $product_value, $method );
@@ -311,16 +311,21 @@ add_filter( 'cfwc_enable_calculation_logging', '__return_true' );
 #### Country-specific valuation override
 
 ```php
-add_filter( 'cfwc_customs_value', function( $customs_value, $line_total, $cart_item, $method ) {
+add_filter( 'cfwc_customs_value', function( $customs_value, $line_total, $cart_item, $method, $rule ) {
     $destination = WC()->customer->get_shipping_country();
 
-    // Force FOB for US/Canada even if CIF is enabled globally
+    // Force FOB for US/Canada even if CIF is enabled globally.
     if ( in_array( $destination, array( 'US', 'CA' ), true ) ) {
-        return $line_total; // Return product value only
+        return $line_total; // Return product value only.
+    }
+
+    // Example: Add an arbitrary surcharge to the customs value for a specific rule.
+    if ( ! empty( $rule['label'] ) && false !== strpos( $rule['label'], 'Special' ) ) {
+        $customs_value += 10;
     }
 
     return $customs_value;
-}, 10, 4 );
+}, 10, 5 );
 ```
 
 ---

--- a/includes/admin/class-cfwc-admin.php
+++ b/includes/admin/class-cfwc-admin.php
@@ -57,7 +57,12 @@ class CFWC_Admin {
 		// Check for rule dependency errors (cycle or unresolvable deps).
 		$dependency_error = get_transient( 'cfwc_rules_dependency_error' );
 		if ( ! empty( $dependency_error ) ) {
-			echo '<div class="notice notice-warning is-dismissible"><p><strong>' . esc_html__( 'Customs Fees Warning', 'customs-fees-for-woocommerce' ) . ':</strong> ' . esc_html( $dependency_error ) . '</p></div>';
+			delete_transient( 'cfwc_rules_dependency_error' );
+			echo '<div class="notice notice-warning is-dismissible"><p><strong>'
+				. esc_html__( 'Customs Fees Warning', 'customs-fees-for-woocommerce' )
+				. ':</strong> '
+				. esc_html( implode( ', ', (array) $dependency_error ) )
+				. '</p></div>';
 		}
 	}
 

--- a/includes/admin/class-cfwc-admin.php
+++ b/includes/admin/class-cfwc-admin.php
@@ -471,7 +471,7 @@ class CFWC_Admin {
 					'delete_confirm'             => __( 'Click the delete button again to confirm deletion.', 'customs-fees-for-woocommerce' ),
 					'no_rules'                   => __( 'No rules configured. Use the preset loader above or add rules manually.', 'customs-fees-for-woocommerce' ),
 					'not_set'                    => __( 'Not set', 'customs-fees-for-woocommerce' ),
-					'valuation_method'           => __( 'Valuation Method', 'customs-fees-for-woocommerce' ),
+					'valuation_method'           => __( 'Valuation method', 'customs-fees-for-woocommerce' ),
 					'depends_on'                 => __( 'Depends on', 'customs-fees-for-woocommerce' ),
 					'inherit_global'             => __( 'Inherit global', 'customs-fees-for-woocommerce' ),
 					'overrides_global'           => __( 'Overrides global valuation', 'customs-fees-for-woocommerce' ),

--- a/includes/admin/class-cfwc-admin.php
+++ b/includes/admin/class-cfwc-admin.php
@@ -53,6 +53,12 @@ class CFWC_Admin {
 	public function admin_notices() {
 		// Activation notices are now handled by CFWC_Onboarding class.
 		// This prevents duplicate notices on activation.
+
+		// Check for rule dependency errors (cycle or unresolvable deps).
+		$dependency_error = get_transient( 'cfwc_rules_dependency_error' );
+		if ( ! empty( $dependency_error ) ) {
+			echo '<div class="notice notice-warning is-dismissible"><p><strong>' . esc_html__( 'Customs Fees Warning', 'customs-fees-for-woocommerce' ) . ':</strong> ' . esc_html( $dependency_error ) . '</p></div>';
+		}
 	}
 
 	/**
@@ -460,7 +466,13 @@ class CFWC_Admin {
 					'delete_confirm'             => __( 'Click the delete button again to confirm deletion.', 'customs-fees-for-woocommerce' ),
 					'no_rules'                   => __( 'No rules configured. Use the preset loader above or add rules manually.', 'customs-fees-for-woocommerce' ),
 					'not_set'                    => __( 'Not set', 'customs-fees-for-woocommerce' ),
-				),
+					'valuation_method'           => __( 'Valuation Method', 'customs-fees-for-woocommerce' ),
+					'depends_on'                 => __( 'Depends on', 'customs-fees-for-woocommerce' ),
+					'inherit_global'             => __( 'Inherit global', 'customs-fees-for-woocommerce' ),
+					'overrides_global'           => __( 'Overrides global valuation', 'customs-fees-for-woocommerce' ),
+					'select_fees_include'        => __( 'Select fees to include in base', 'customs-fees-for-woocommerce' ),
+					'cycle_warning'              => __( 'Rule dependency cycle detected. Some rules may not calculate correctly.', 'customs-fees-for-woocommerce' ),
+			),
 			)
 		);
 	}

--- a/includes/admin/class-cfwc-admin.php
+++ b/includes/admin/class-cfwc-admin.php
@@ -55,9 +55,12 @@ class CFWC_Admin {
 		// This prevents duplicate notices on activation.
 
 		// Check for rule dependency errors (cycle or unresolvable deps).
+		// The transient is kept in sync with the saved rules by
+		// CFWC_Calculator::refresh_cycle_notice() at every mutation site, so
+		// the notice persists across pageloads until a save resolves the
+		// cycle — `is-dismissible` still hides it for the current pageview.
 		$dependency_error = get_transient( 'cfwc_rules_dependency_error' );
 		if ( ! empty( $dependency_error ) ) {
-			delete_transient( 'cfwc_rules_dependency_error' );
 			echo '<div class="notice notice-warning is-dismissible"><p><strong>'
 				. esc_html__( 'Customs Fees Warning', 'customs-fees-for-woocommerce' )
 				. ':</strong> '

--- a/includes/admin/class-cfwc-admin.php
+++ b/includes/admin/class-cfwc-admin.php
@@ -29,6 +29,9 @@ class CFWC_Admin {
 		// Add admin notices.
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 
+		// Persist dismissal of the broken-dependency notice.
+		add_action( 'wp_ajax_cfwc_dismiss_broken_dependency', array( $this, 'ajax_dismiss_broken_dependency' ) );
+
 		// Add order admin meta boxes.
 		add_action( 'add_meta_boxes', array( $this, 'add_order_meta_boxes' ) );
 
@@ -67,6 +70,112 @@ class CFWC_Admin {
 				. esc_html( implode( ', ', (array) $dependency_error ) )
 				. '</p></div>';
 		}
+
+		// A surviving rule's base_includes dependency was removed by a higher-
+		// priority override/exclusive rule, so its fee compounds on an incomplete
+		// base. Computed on demand on the settings screen only (see method).
+		$this->maybe_show_broken_dependency_notice();
+	}
+
+	/**
+	 * Show the broken-dependency notice on the Customs Fees settings screen.
+	 *
+	 * Unlike the cycle notice, this is derived on demand from the saved rules
+	 * rather than cached in a transient: the check is a cheap pure function, so
+	 * it is always current and needs no invalidation. It runs only on the
+	 * Customs & Import Fees settings section to avoid any cost on other admin
+	 * pages, where the notice would not be actionable anyway.
+	 *
+	 * Dismissal is persisted via the `cfwc_dismissed_broken_dependency` option,
+	 * keyed to the signature of the affected rules so the notice re-surfaces if
+	 * the conflict later changes, and is cleared automatically once resolved.
+	 *
+	 * @since 1.2.0
+	 */
+	public function maybe_show_broken_dependency_notice() {
+		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( ! $screen || 'woocommerce_page_wc-settings' !== $screen->id ) {
+			return;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only screen gate; no state change.
+		$tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : '';
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only screen gate; no state change.
+		$section = isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : '';
+		if ( 'tax' !== $tab || 'customs' !== $section ) {
+			return;
+		}
+
+		if ( ! current_user_can( 'manage_woocommerce' ) || ! class_exists( 'CFWC_Rule_Matcher' ) ) {
+			return;
+		}
+
+		$broken = CFWC_Rule_Matcher::detect_broken_dependencies( get_option( 'cfwc_rules', array() ) );
+
+		if ( empty( $broken ) ) {
+			// Conflict resolved (or never existed): drop any stale dismissal so a
+			// future re-introduction of a conflict is shown again.
+			delete_option( 'cfwc_dismissed_broken_dependency' );
+			return;
+		}
+
+		$signature = CFWC_Rule_Matcher::broken_dependency_signature( $broken );
+
+		// Respect the merchant's decision to keep this exact configuration.
+		if ( get_option( 'cfwc_dismissed_broken_dependency' ) === $signature ) {
+			return;
+		}
+
+		$message = sprintf(
+			/* translators: %s: comma-separated list of affected rule names. */
+			__( 'These rules depend on another rule that your stacking settings remove, so their fee is calculated on an incomplete base: %s. Review the priority and stacking mode of any override or exclusive rules for the same destination.', 'customs-fees-for-woocommerce' ),
+			implode( ', ', (array) $broken )
+		);
+		?>
+		<div class="notice notice-warning is-dismissible cfwc-broken-dependency-notice">
+			<p>
+				<strong><?php esc_html_e( 'Customs Fees Warning', 'customs-fees-for-woocommerce' ); ?>:</strong>
+				<?php echo esc_html( $message ); ?>
+			</p>
+		</div>
+		<script type="text/javascript">
+		jQuery( function ( $ ) {
+			$( '.cfwc-broken-dependency-notice' ).on( 'click', '.notice-dismiss', function () {
+				$.post( ajaxurl, {
+					action: 'cfwc_dismiss_broken_dependency',
+					nonce: '<?php echo esc_js( wp_create_nonce( 'cfwc_dismiss_broken_dependency' ) ); ?>'
+				} );
+			} );
+		} );
+		</script>
+		<?php
+	}
+
+	/**
+	 * Persist dismissal of the broken-dependency notice.
+	 *
+	 * Recomputes the current signature server-side so a dismissal only suppresses
+	 * the configuration the merchant actually saw, not a value supplied by the
+	 * client.
+	 *
+	 * @since 1.2.0
+	 */
+	public function ajax_dismiss_broken_dependency() {
+		check_ajax_referer( 'cfwc_dismiss_broken_dependency', 'nonce' );
+
+		if ( ! current_user_can( 'manage_woocommerce' ) || ! class_exists( 'CFWC_Rule_Matcher' ) ) {
+			wp_die();
+		}
+
+		$broken = CFWC_Rule_Matcher::detect_broken_dependencies( get_option( 'cfwc_rules', array() ) );
+		if ( ! empty( $broken ) ) {
+			update_option(
+				'cfwc_dismissed_broken_dependency',
+				CFWC_Rule_Matcher::broken_dependency_signature( $broken )
+			);
+		}
+
+		wp_die();
 	}
 
 	/**

--- a/includes/admin/class-cfwc-admin.php
+++ b/includes/admin/class-cfwc-admin.php
@@ -124,15 +124,15 @@ class CFWC_Admin {
 			if ( ! empty( $breakdown ) && is_array( $breakdown ) ) {
 				// Show detailed breakdown.
 				echo '<strong>' . esc_html__( 'Fees Breakdown:', 'customs-fees-for-woocommerce' ) . '</strong>';
-				echo '<ul style="margin: 10px 0; padding-left: 20px;">';
+				echo '<ul class="cfwc-fees-breakdown-list">';
 				foreach ( $breakdown as $fee_item ) {
-					echo '<li style="margin: 5px 0;">';
+					echo '<li>';
 					echo esc_html( $fee_item['label'] ) . ': ';
 					echo '<strong>' . wp_kses_post( wc_price( $fee_item['amount'] ) ) . '</strong>';
 					echo '</li>';
 				}
 				echo '</ul>';
-				echo '<hr style="margin: 10px 0;">';
+				echo '<hr class="cfwc-fees-divider">';
 				echo '<p><strong>' . esc_html__( 'Total:', 'customs-fees-for-woocommerce' ) . '</strong> ' . wp_kses_post( wc_price( $total_fees ) ) . '</p>';
 			} else {
 				// Fallback to simple total.
@@ -146,9 +146,9 @@ class CFWC_Admin {
 		// Display HS codes and origin for order items.
 		$items = $order->get_items();
 		if ( ! empty( $items ) ) {
-			echo '<hr style="margin: 15px 0;">';
+			echo '<hr class="cfwc-section-divider">';
 			echo '<p><strong>' . esc_html__( 'Product Customs Information:', 'customs-fees-for-woocommerce' ) . '</strong></p>';
-			echo '<ul style="margin: 10px 0 0 20px;">';
+			echo '<ul class="cfwc-product-customs-list">';
 
 			foreach ( $items as $item ) {
 				if ( ! is_a( $item, 'WC_Order_Item_Product' ) ) {
@@ -196,7 +196,7 @@ class CFWC_Admin {
 		echo '<div class="options_group show_if_simple show_if_variable">';
 
 		// Add a heading without grey background to match WooCommerce style.
-		echo '<h4 style="margin: 10px 12px 5px; font-size: 14px; font-weight: 600;">' . esc_html__( 'Customs & Import Fees', 'customs-fees-for-woocommerce' ) . '</h4>';
+		echo '<h4 class="cfwc-product-fields-heading">' . esc_html__( 'Customs & Import Fees', 'customs-fees-for-woocommerce' ) . '</h4>';
 
 		woocommerce_wp_text_input(
 			array(
@@ -210,7 +210,7 @@ class CFWC_Admin {
 		);
 
 		// Add help text with link after HS Code field.
-		echo '<p class="cfwc-hs-code-help" style="margin-left: 154px; margin-top: -10px; margin-bottom: 10px; font-size: 12px; color: #666;">';
+		echo '<p class="cfwc-hs-code-help">';
 		echo esc_html__( 'You can ', 'customs-fees-for-woocommerce' );
 		echo '<a href="https://hts.usitc.gov/" target="_blank" rel="noopener noreferrer">';
 		echo esc_html__( 'find HS codes here', 'customs-fees-for-woocommerce' );
@@ -524,7 +524,7 @@ class CFWC_Admin {
 
 		// Display as meta data similar to SKU.
 		if ( $hs_code || $origin ) {
-			echo '<div class="cfwc-order-item-meta" style="margin-top: 0.5em;">';
+			echo '<div class="cfwc-order-item-meta">';
 			echo '<table cellspacing="0" class="display_meta">';
 
 			if ( $hs_code ) {

--- a/includes/admin/class-cfwc-admin.php
+++ b/includes/admin/class-cfwc-admin.php
@@ -475,9 +475,19 @@ class CFWC_Admin {
 					'depends_on'                 => __( 'Depends on', 'customs-fees-for-woocommerce' ),
 					'inherit_global'             => __( 'Inherit global', 'customs-fees-for-woocommerce' ),
 					'overrides_global'           => __( 'Overrides global valuation', 'customs-fees-for-woocommerce' ),
+					'overrides_global_for_rule'  => __( 'Overrides global for this rule', 'customs-fees-for-woocommerce' ),
 					'select_fees_include'        => __( 'Select fees to include in base', 'customs-fees-for-woocommerce' ),
 					'cycle_warning'              => __( 'Rule dependency cycle detected. Some rules may not calculate correctly.', 'customs-fees-for-woocommerce' ),
-			),
+					'fob'                        => __( 'FOB', 'customs-fees-for-woocommerce' ),
+					'cif'                        => __( 'CIF', 'customs-fees-for-woocommerce' ),
+					'cif_insurance'              => __( 'CIF + Insurance', 'customs-fees-for-woocommerce' ),
+					'cif_insurance_short'        => __( 'CIF + Ins', 'customs-fees-for-woocommerce' ),
+					'global_label'               => __( 'Global', 'customs-fees-for-woocommerce' ),
+					/* translators: %d: count of dependency fees included in the base */
+					'dep_fee_singular'           => __( '+%d fee', 'customs-fees-for-woocommerce' ),
+					/* translators: %d: count of dependency fees included in the base */
+					'dep_fee_plural'             => __( '+%d fees', 'customs-fees-for-woocommerce' ),
+				),
 			)
 		);
 	}

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -347,6 +347,8 @@ class CFWC_Ajax {
 			$header_map[ strtolower( trim( $header ) ) ] = $index;
 		}
 
+		$header_count = count( $headers );
+
 		foreach ( $lines as $line ) {
 			if ( empty( trim( $line ) ) ) {
 				continue;
@@ -354,14 +356,25 @@ class CFWC_Ajax {
 
 			// Add escape parameter (backslash) for PHP 8.4+ compatibility.
 			$data = str_getcsv( $line, ',', '"', '\\' );
-			if ( count( $data ) !== count( $headers ) ) {
+
+			// Skip rows that have no data at all.
+			if ( empty( $data ) ) {
 				continue;
+			}
+
+			// Tolerate row width drift: pad short rows (Excel/Sheets often
+			// strips trailing empty columns on save) and truncate long ones
+			// so the header_map lookups stay in bounds.
+			if ( count( $data ) < $header_count ) {
+				$data = array_pad( $data, $header_count, '' );
+			} elseif ( count( $data ) > $header_count ) {
+				$data = array_slice( $data, 0, $header_count );
 			}
 
 			// Helper to safely read a column by header name.
 			$get = function ( $name, $default = '' ) use ( $data, $header_map ) {
 				$index = $header_map[ strtolower( $name ) ] ?? null;
-				return ( null !== $index && isset( $data[ $index ] ) ) ? $data[ $index ] : $default;
+				return ( null !== $index && isset( $data[ $index ] ) && '' !== $data[ $index ] ) ? $data[ $index ] : $default;
 			};
 
 			$base_includes_raw = $get( 'depends on', '' );

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -380,8 +380,18 @@ class CFWC_Ajax {
 				$base_includes = array_values( array_unique( array_filter( array_map( 'trim', explode( '|', $base_includes_raw ) ) ) ) );
 			}
 
+			$country_value    = sanitize_text_field( $get( 'country', '' ) );
+			$to_country_value = sanitize_text_field( $get( 'to country', '' ) );
+
+			// Mirror the settings save validation: a rule must declare at least
+			// one destination (legacy `country` or new `to_country`). Otherwise
+			// the row is dropped so importers don't end up with inert rules.
+			if ( '' === $country_value && '' === $to_country_value ) {
+				continue;
+			}
+
 			$new_rules[] = array(
-				'country'          => sanitize_text_field( $get( 'country', '' ) ),
+				'country'          => $country_value,
 				'type'             => sanitize_text_field( $get( 'type', 'percentage' ) ),
 				'rate'             => floatval( $get( 'rate', 0 ) ),
 				'amount'           => floatval( $get( 'amount', 0 ) ),
@@ -394,7 +404,7 @@ class CFWC_Ajax {
 					? sanitize_text_field( $get( 'rule id' ) )
 					: 'rule_' . wp_generate_uuid4(),
 				'from_country'     => sanitize_text_field( $get( 'from country', '' ) ),
-				'to_country'       => sanitize_text_field( $get( 'to country', '' ) ),
+				'to_country'       => $to_country_value,
 				'match_type'       => sanitize_text_field( $get( 'match type', 'all' ) ),
 				'hs_code_pattern'  => sanitize_text_field( $get( 'hs code', '' ) ),
 				'priority'         => absint( $get( 'priority', 0 ) ),

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -272,21 +272,31 @@ class CFWC_Ajax {
 
 		$rules = get_option( 'cfwc_rules', array() );
 
-		// Create CSV content.
-		$csv_content = "Country,Type,Rate,Amount,Minimum,Maximum,Label,Taxable,Tax Class\n";
+		// Create CSV content with all rule fields.
+		$csv_content = "Country,Type,Rate,Amount,Minimum,Maximum,Label,Taxable,Tax Class,Rule ID,From Country,To Country,Match Type,HS Code,Priority,Stacking Mode,Valuation Method,Depends On\n";
 
 		foreach ( $rules as $rule ) {
-			$csv_content .= sprintf(
-				'"%s","%s",%.2f,%.2f,%.2f,%.2f,"%s","%s","%s"' . "\n",
-				$rule['country'],
-				$rule['type'],
-				$rule['rate'],
-				$rule['amount'],
-				$rule['minimum'],
-				$rule['maximum'],
-				$rule['label'],
-				$rule['taxable'] ? 'yes' : 'no',
-				$rule['tax_class']
+			$base_includes = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] ) ? implode( '|', $rule['base_includes'] ) : '';
+			$csv_content  .= sprintf(
+				'"%s","%s",%.2f,%.2f,%.2f,%.2f,"%s","%s","%s","%s","%s","%s","%s","%s",%d,"%s","%s","%s"' . "\n",
+				$rule['country'] ?? '',
+				$rule['type'] ?? 'percentage',
+				$rule['rate'] ?? 0,
+				$rule['amount'] ?? 0,
+				$rule['minimum'] ?? 0,
+				$rule['maximum'] ?? 0,
+				$rule['label'] ?? '',
+				! empty( $rule['taxable'] ) ? 'yes' : 'no',
+				$rule['tax_class'] ?? '',
+				$rule['rule_id'] ?? '',
+				$rule['from_country'] ?? '',
+				$rule['to_country'] ?? '',
+				$rule['match_type'] ?? 'all',
+				$rule['hs_code_pattern'] ?? '',
+				$rule['priority'] ?? 0,
+				$rule['stacking_mode'] ?? 'add',
+				$rule['valuation_method'] ?? 'inherit',
+				$base_includes
 			);
 		}
 
@@ -331,6 +341,12 @@ class CFWC_Ajax {
 		$headers   = str_getcsv( array_shift( $lines ), ',', '"', '\\' );
 		$new_rules = array();
 
+		// Build header index map for flexible column mapping.
+		$header_map = array();
+		foreach ( $headers as $index => $header ) {
+			$header_map[ strtolower( trim( $header ) ) ] = $index;
+		}
+
 		foreach ( $lines as $line ) {
 			if ( empty( trim( $line ) ) ) {
 				continue;
@@ -338,19 +354,46 @@ class CFWC_Ajax {
 
 			// Add escape parameter (backslash) for PHP 8.4+ compatibility.
 			$data = str_getcsv( $line, ',', '"', '\\' );
-			if ( count( $data ) === count( $headers ) ) {
-				$new_rules[] = array(
-					'country'   => sanitize_text_field( $data[0] ),
-					'type'      => sanitize_text_field( $data[1] ),
-					'rate'      => floatval( $data[2] ),
-					'amount'    => floatval( $data[3] ),
-					'minimum'   => floatval( $data[4] ),
-					'maximum'   => floatval( $data[5] ),
-					'label'     => sanitize_text_field( $data[6] ),
-					'taxable'   => 'yes' === strtolower( $data[7] ),
-					'tax_class' => sanitize_text_field( $data[8] ),
-				);
+			if ( count( $data ) !== count( $headers ) ) {
+				continue;
 			}
+
+			// Helper to safely read a column by header name.
+			$get = function ( $name, $default = '' ) use ( $data, $header_map ) {
+				$index = $header_map[ strtolower( $name ) ] ?? null;
+				return ( null !== $index && isset( $data[ $index ] ) ) ? $data[ $index ] : $default;
+			};
+
+			$base_includes_raw = $get( 'depends on', '' );
+			$base_includes     = array();
+			if ( ! empty( $base_includes_raw ) ) {
+				$base_includes = array_values( array_unique( array_filter( array_map( 'trim', explode( '|', $base_includes_raw ) ) ) ) );
+			}
+
+			$new_rules[] = array(
+				'country'          => sanitize_text_field( $get( 'country', '' ) ),
+				'type'             => sanitize_text_field( $get( 'type', 'percentage' ) ),
+				'rate'             => floatval( $get( 'rate', 0 ) ),
+				'amount'           => floatval( $get( 'amount', 0 ) ),
+				'minimum'          => floatval( $get( 'minimum', 0 ) ),
+				'maximum'          => floatval( $get( 'maximum', 0 ) ),
+				'label'            => sanitize_text_field( $get( 'label', '' ) ),
+				'taxable'          => 'yes' === strtolower( $get( 'taxable', 'yes' ) ),
+				'tax_class'        => sanitize_text_field( $get( 'tax class', '' ) ),
+				'rule_id'          => ! empty( $get( 'rule id', '' ) )
+					? sanitize_text_field( $get( 'rule id' ) )
+					: 'rule_' . wp_generate_uuid4(),
+				'from_country'     => sanitize_text_field( $get( 'from country', '' ) ),
+				'to_country'       => sanitize_text_field( $get( 'to country', '' ) ),
+				'match_type'       => sanitize_text_field( $get( 'match type', 'all' ) ),
+				'hs_code_pattern'  => sanitize_text_field( $get( 'hs code', '' ) ),
+				'priority'         => absint( $get( 'priority', 0 ) ),
+				'stacking_mode'    => sanitize_text_field( $get( 'stacking mode', 'add' ) ),
+				'valuation_method' => in_array( $get( 'valuation method', 'inherit' ), array( 'inherit', 'fob', 'cif', 'cif_insurance' ), true )
+					? $get( 'valuation method', 'inherit' )
+					: 'inherit',
+				'base_includes'    => $base_includes,
+			);
 		}
 
 		if ( empty( $new_rules ) ) {

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -494,10 +494,11 @@ class CFWC_Ajax {
 		}
 
 		// One-shot cycle detection over the matching set.
+		$calc_instance  = new CFWC_Calculator();
 		$cycle_rule_ids = array();
 		foreach ( $matching as $cr ) {
 			$cr_id = $cr['rule_id'] ?? '';
-			if ( '' !== $cr_id && self::test_has_cycle( $matching, $cr_id ) ) {
+			if ( '' !== $cr_id && $calc_instance->has_cycle( $matching, $cr_id ) ) {
 				$cycle_rule_ids[ $cr_id ] = true;
 			}
 		}
@@ -645,45 +646,4 @@ class CFWC_Ajax {
 		return $fee_amount;
 	}
 
-	/**
-	 * Detect a base_includes cycle for the given rule via DFS.
-	 *
-	 * @since 1.2.0
-	 * @param array  $rules    Matching rules.
-	 * @param string $start_id Rule ID to inspect.
-	 * @param array  $visited  Current DFS path (snapshot per recursive call).
-	 * @return bool True if a cycle is detected.
-	 */
-	private static function test_has_cycle( $rules, $start_id, $visited = array() ) {
-		$rule_map = array();
-		foreach ( $rules as $rule ) {
-			$rid = isset( $rule['rule_id'] ) ? $rule['rule_id'] : '';
-			if ( '' !== $rid ) {
-				$rule_map[ $rid ] = $rule;
-			}
-		}
-
-		if ( ! isset( $rule_map[ $start_id ] ) ) {
-			return false;
-		}
-
-		$rule = $rule_map[ $start_id ];
-		$deps = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] ) ? $rule['base_includes'] : array();
-
-		foreach ( $deps as $dep_id ) {
-			if ( $dep_id === $start_id ) {
-				return true;
-			}
-			if ( in_array( $dep_id, $visited, true ) ) {
-				return true;
-			}
-			$path   = $visited;
-			$path[] = $dep_id;
-			if ( self::test_has_cycle( $rules, $dep_id, $path ) ) {
-				return true;
-			}
-		}
-
-		return false;
-	}
 }

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -121,8 +121,7 @@ class CFWC_Ajax {
 		update_option( 'cfwc_rules', $rules );
 
 		// Clear cache.
-		$calculator = new CFWC_Calculator();
-		$calculator->clear_cache();
+		CFWC_Calculator::clear_cache();
 
 		wp_send_json_success(
 			array(
@@ -191,8 +190,7 @@ class CFWC_Ajax {
 			update_option( 'cfwc_rules', $rules );
 
 			// Clear cache.
-			$calculator = new CFWC_Calculator();
-			$calculator->clear_cache();
+			CFWC_Calculator::clear_cache();
 
 			wp_send_json_success(
 				array(
@@ -247,8 +245,7 @@ class CFWC_Ajax {
 		update_option( 'cfwc_rules', $reordered );
 
 		// Clear cache.
-		$calculator = new CFWC_Calculator();
-		$calculator->clear_cache();
+		CFWC_Calculator::clear_cache();
 
 		wp_send_json_success(
 			array(
@@ -427,8 +424,7 @@ class CFWC_Ajax {
 		update_option( 'cfwc_rules', $new_rules );
 
 		// Clear cache.
-		$calculator = new CFWC_Calculator();
-		$calculator->clear_cache();
+		CFWC_Calculator::clear_cache();
 
 		wp_send_json_success(
 			array(
@@ -494,11 +490,10 @@ class CFWC_Ajax {
 		}
 
 		// One-shot cycle detection over the matching set.
-		$calc_instance  = new CFWC_Calculator();
 		$cycle_rule_ids = array();
 		foreach ( $matching as $cr ) {
 			$cr_id = $cr['rule_id'] ?? '';
-			if ( '' !== $cr_id && $calc_instance->has_cycle( $matching, $cr_id ) ) {
+			if ( '' !== $cr_id && CFWC_Calculator::has_cycle( $matching, $cr_id ) ) {
 				$cycle_rule_ids[ $cr_id ] = true;
 			}
 		}

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -75,15 +75,44 @@ class CFWC_Ajax {
 			'hs_code_pattern' => sanitize_text_field( $rule_data['hs_code_pattern'] ?? '' ),
 			'priority'        => absint( $rule_data['priority'] ?? 0 ),
 			'stacking_mode'   => sanitize_text_field( $rule_data['stacking_mode'] ?? 'add' ),
+			// New fields for per-rule valuation and compound bases (v1.2.0).
+			'rule_id'         => ! empty( $rule_data['rule_id'] )
+				? sanitize_text_field( $rule_data['rule_id'] )
+				: 'rule_' . wp_generate_uuid4(),
+			'valuation_method' => in_array( $rule_data['valuation_method'] ?? '', array( 'inherit', 'fob', 'cif', 'cif_insurance' ), true )
+				? $rule_data['valuation_method']
+				: 'inherit',
+			'base_includes'   => isset( $rule_data['base_includes'] ) && is_array( $rule_data['base_includes'] )
+				? array_values( array_unique( array_map( 'sanitize_text_field', $rule_data['base_includes'] ) ) )
+				: array(),
 		);
 
 		// Get existing rules.
 		$rules = get_option( 'cfwc_rules', array() );
 
+		// Normalize before save.
+		if ( class_exists( 'CFWC_Settings' ) && method_exists( 'CFWC_Settings', 'migrate_rules' ) ) {
+			$rules = CFWC_Settings::migrate_rules( $rules );
+		}
+
 		// Update or add rule.
+		$updated = false;
 		if ( null !== $rule_id && isset( $rules[ $rule_id ] ) ) {
 			$rules[ $rule_id ] = $rule;
+			$updated = true;
 		} else {
+			// Try matching by rule_id string for existing rules.
+			foreach ( $rules as $index => $existing_rule ) {
+				if ( isset( $existing_rule['rule_id'] ) && $existing_rule['rule_id'] === $rule['rule_id'] ) {
+					$rules[ $index ] = $rule;
+					$rule_id         = $index;
+					$updated         = true;
+					break;
+				}
+			}
+		}
+
+		if ( ! $updated ) {
 			$rules[] = $rule;
 			$rule_id = count( $rules ) - 1;
 		}
@@ -117,9 +146,11 @@ class CFWC_Ajax {
 			wp_die( -1 );
 		}
 
-		$rule_id = isset( $_POST['rule_id'] ) ? absint( $_POST['rule_id'] ) : null;
+		// Support both string rule_id (new) and numeric index (legacy).
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$raw_rule_id = isset( $_POST['rule_id'] ) ? wp_unslash( $_POST['rule_id'] ) : null;
 
-		if ( null === $rule_id ) {
+		if ( null === $raw_rule_id || '' === $raw_rule_id ) {
 			wp_send_json_error(
 				array(
 					'message' => __( 'Invalid rule ID.', 'customs-fees-for-woocommerce' ),
@@ -130,9 +161,29 @@ class CFWC_Ajax {
 		// Get existing rules.
 		$rules = get_option( 'cfwc_rules', array() );
 
+		$rule_index = null;
+
+		// Try matching by string rule_id first.
+		if ( is_string( $raw_rule_id ) ) {
+			foreach ( $rules as $index => $existing_rule ) {
+				if ( isset( $existing_rule['rule_id'] ) && $existing_rule['rule_id'] === $raw_rule_id ) {
+					$rule_index = $index;
+					break;
+				}
+			}
+		}
+
+		// Fallback to numeric index for legacy clients.
+		if ( null === $rule_index ) {
+			$numeric_id = absint( $raw_rule_id );
+			if ( isset( $rules[ $numeric_id ] ) ) {
+				$rule_index = $numeric_id;
+			}
+		}
+
 		// Remove rule.
-		if ( isset( $rules[ $rule_id ] ) ) {
-			unset( $rules[ $rule_id ] );
+		if ( null !== $rule_index && isset( $rules[ $rule_index ] ) ) {
+			unset( $rules[ $rule_index ] );
 			// Re-index array.
 			$rules = array_values( $rules );
 

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -146,10 +146,9 @@ class CFWC_Ajax {
 		}
 
 		// Support both string rule_id (new) and numeric index (legacy).
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$raw_rule_id = isset( $_POST['rule_id'] ) ? wp_unslash( $_POST['rule_id'] ) : null;
+		$raw_rule_id = isset( $_POST['rule_id'] ) ? sanitize_text_field( wp_unslash( $_POST['rule_id'] ) ) : '';
 
-		if ( null === $raw_rule_id || '' === $raw_rule_id ) {
+		if ( '' === $raw_rule_id ) {
 			wp_send_json_error(
 				array(
 					'message' => __( 'Invalid rule ID.', 'customs-fees-for-woocommerce' ),
@@ -163,12 +162,10 @@ class CFWC_Ajax {
 		$rule_index = null;
 
 		// Try matching by string rule_id first.
-		if ( is_string( $raw_rule_id ) ) {
-			foreach ( $rules as $index => $existing_rule ) {
-				if ( isset( $existing_rule['rule_id'] ) && $existing_rule['rule_id'] === $raw_rule_id ) {
-					$rule_index = $index;
-					break;
-				}
+		foreach ( $rules as $index => $existing_rule ) {
+			if ( isset( $existing_rule['rule_id'] ) && $existing_rule['rule_id'] === $raw_rule_id ) {
+				$rule_index = $index;
+				break;
 			}
 		}
 

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -453,47 +453,84 @@ class CFWC_Ajax {
 			);
 		}
 
-		// Calculate fees by simulating a cart.
-		// Since calculate_fees_for_country doesn't exist, we need to simulate the calculation.
-		$calculator = new CFWC_Calculator();
+		// Test tool uses cart_total as the FOB base and resolves base_includes;
+		// per-product shipping share is unavailable here, so cif/cif_insurance
+		// fall back to cart_total (with global insurance percentage added when
+		// method is cif_insurance and a percentage is configured).
+		$all_rules     = get_option( 'cfwc_rules', array() );
+		$global_method = get_option( 'cfwc_valuation_method', 'fob' );
 
-		// Get rules and filter by country to simulate the calculation.
-		$all_rules  = get_option( 'cfwc_rules', array() );
+		$matching = array();
+		foreach ( $all_rules as $key => $rule ) {
+			$rule_country = $rule['to_country'] ?? $rule['country'] ?? '';
+			if ( $rule_country !== $country ) {
+				continue;
+			}
+			if ( empty( $rule['rule_id'] ) ) {
+				$rule['rule_id'] = (string) $key;
+			}
+			$matching[] = $rule;
+		}
+
+		$id_to_rule = array();
+		foreach ( $matching as $mr ) {
+			$rid = isset( $mr['rule_id'] ) ? $mr['rule_id'] : '';
+			if ( '' !== $rid ) {
+				$id_to_rule[ $rid ] = $mr;
+			}
+		}
+
+		// One-shot cycle detection over the matching set.
+		$cycle_rule_ids = array();
+		foreach ( $matching as $cr ) {
+			$cr_id = $cr['rule_id'] ?? '';
+			if ( '' !== $cr_id && self::test_has_cycle( $matching, $cr_id ) ) {
+				$cycle_rule_ids[ $cr_id ] = true;
+			}
+		}
+
 		$fees       = array();
 		$total_fees = 0;
+		$calculated = array();
+		$pending    = $matching;
+		$rounds     = 0;
+		$max_rounds = count( $matching ) + 1;
 
-		// Filter rules for the specified country (check both legacy and new format).
-		foreach ( $all_rules as $rule ) {
-			$rule_country = $rule['to_country'] ?? $rule['country'] ?? '';
-			if ( $rule_country === $country ) {
-				$fee_amount = 0;
-				$base       = $cart_total;
+		while ( ! empty( $pending ) && $rounds < $max_rounds ) {
+			++$rounds;
+			$made_progress = false;
+			$still_pending = array();
 
-				// Apply per-rule valuation method.
-				$valuation = $rule['valuation_method'] ?? 'inherit';
-				$global_method = get_option( 'cfwc_valuation_method', 'fob' );
-				$method    = ( 'inherit' !== $valuation ) ? $valuation : $global_method;
-				// Note: shipping proportion cannot be calculated without line-item
-				// context, so CIF is approximated by the caller providing a total
-				// that already includes shipping when desired.
+			foreach ( $pending as $rule ) {
+				$rule_id = $rule['rule_id'] ?? '';
+				$deps    = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] )
+					? $rule['base_includes']
+					: array();
+				$deps    = array_filter(
+					$deps,
+					function ( $dep_id ) use ( $id_to_rule ) {
+						return isset( $id_to_rule[ $dep_id ] );
+					}
+				);
 
-				// Calculate based on rule type.
-				if ( 'percentage' === $rule['type'] ) {
-					$fee_amount = ( $base * $rule['rate'] ) / 100;
-				} elseif ( 'flat' === $rule['type'] ) {
-					$fee_amount = $rule['amount'];
+				$deps_ready = true;
+				foreach ( $deps as $dep_id ) {
+					if ( ! isset( $calculated[ $dep_id ] ) ) {
+						$deps_ready = false;
+						break;
+					}
 				}
 
-				// Apply minimum/maximum limits if set.
-				if ( isset( $rule['minimum'] ) && $rule['minimum'] > 0 && $fee_amount < $rule['minimum'] ) {
-					$fee_amount = $rule['minimum'];
+				if ( ! $deps_ready ) {
+					$still_pending[] = $rule;
+					continue;
 				}
-				if ( isset( $rule['maximum'] ) && $rule['maximum'] > 0 && $fee_amount > $rule['maximum'] ) {
-					$fee_amount = $rule['maximum'];
-				}
+
+				$fee_amount = self::compute_test_fee( $rule, $cart_total, $deps, $calculated, $cycle_rule_ids, $global_method );
 
 				if ( $fee_amount > 0 ) {
-					$fees[]      = array(
+					$calculated[ $rule_id ] = $fee_amount;
+					$fees[]                 = array(
 						'label'  => isset( $rule['label'] ) ? $rule['label'] : __( 'Customs Fee', 'customs-fees-for-woocommerce' ),
 						'amount' => $fee_amount,
 						'type'   => $rule['type'],
@@ -501,6 +538,33 @@ class CFWC_Ajax {
 					);
 					$total_fees += $fee_amount;
 				}
+
+				$made_progress = true;
+			}
+
+			$pending = $still_pending;
+
+			if ( ! $made_progress ) {
+				// Fallback: compute remaining rules on their own base so the
+				// preview still shows something useful when deps cannot resolve.
+				foreach ( $pending as $rule ) {
+					$rule_id    = $rule['rule_id'] ?? '';
+					$fee_amount = self::compute_test_fee( $rule, $cart_total, array(), $calculated, $cycle_rule_ids, $global_method );
+
+					if ( $fee_amount > 0 ) {
+						if ( '' !== $rule_id ) {
+							$calculated[ $rule_id ] = $fee_amount;
+						}
+						$fees[]      = array(
+							'label'  => isset( $rule['label'] ) ? $rule['label'] : __( 'Customs Fee', 'customs-fees-for-woocommerce' ),
+							'amount' => $fee_amount,
+							'type'   => $rule['type'],
+							'rate'   => isset( $rule['rate'] ) ? $rule['rate'] : 0,
+						);
+						$total_fees += $fee_amount;
+					}
+				}
+				break;
 			}
 		}
 
@@ -511,5 +575,102 @@ class CFWC_Ajax {
 				'total'   => $total_fees,
 			)
 		);
+	}
+
+	/**
+	 * Compute a single test fee with per-rule valuation and dependency includes.
+	 *
+	 * @since 1.2.0
+	 * @param array $rule           Rule data.
+	 * @param float $cart_total     Test cart total (treated as the FOB base).
+	 * @param array $deps           Filtered list of dependency rule IDs.
+	 * @param array $calculated     Map of already-computed fees by rule_id.
+	 * @param array $cycle_rule_ids Map of rule IDs that participate in a cycle.
+	 * @param string $global_method Global valuation method.
+	 * @return float Computed fee amount (after min/max limits).
+	 */
+	private static function compute_test_fee( $rule, $cart_total, $deps, $calculated, $cycle_rule_ids, $global_method ) {
+		$valuation = $rule['valuation_method'] ?? 'inherit';
+		$method    = ( 'inherit' !== $valuation ) ? $valuation : $global_method;
+
+		$base = (float) $cart_total;
+
+		if ( 'cif_insurance' === $method ) {
+			$insurance_method = get_option( 'cfwc_insurance_method', 'disabled' );
+			if ( 'percentage' === $insurance_method ) {
+				$pct   = floatval( get_option( 'cfwc_insurance_percentage', 2 ) );
+				$base += ( $cart_total * $pct ) / 100;
+			}
+		}
+
+		$rule_id = $rule['rule_id'] ?? '';
+		if ( '' === $rule_id || ! isset( $cycle_rule_ids[ $rule_id ] ) ) {
+			foreach ( $deps as $dep_id ) {
+				if ( $dep_id === $rule_id ) {
+					continue;
+				}
+				if ( isset( $calculated[ $dep_id ] ) ) {
+					$base += $calculated[ $dep_id ];
+				}
+			}
+		}
+
+		$fee_amount = 0;
+		if ( 'percentage' === $rule['type'] ) {
+			$fee_amount = ( $base * floatval( $rule['rate'] ?? 0 ) ) / 100;
+		} elseif ( 'flat' === $rule['type'] ) {
+			$fee_amount = floatval( $rule['amount'] ?? 0 );
+		}
+
+		if ( isset( $rule['minimum'] ) && $rule['minimum'] > 0 && $fee_amount < $rule['minimum'] ) {
+			$fee_amount = floatval( $rule['minimum'] );
+		}
+		if ( isset( $rule['maximum'] ) && $rule['maximum'] > 0 && $fee_amount > $rule['maximum'] ) {
+			$fee_amount = floatval( $rule['maximum'] );
+		}
+
+		return $fee_amount;
+	}
+
+	/**
+	 * Detect a base_includes cycle for the given rule via DFS.
+	 *
+	 * @since 1.2.0
+	 * @param array  $rules    Matching rules.
+	 * @param string $start_id Rule ID to inspect.
+	 * @param array  $visited  Current DFS path (snapshot per recursive call).
+	 * @return bool True if a cycle is detected.
+	 */
+	private static function test_has_cycle( $rules, $start_id, $visited = array() ) {
+		$rule_map = array();
+		foreach ( $rules as $rule ) {
+			$rid = isset( $rule['rule_id'] ) ? $rule['rule_id'] : '';
+			if ( '' !== $rid ) {
+				$rule_map[ $rid ] = $rule;
+			}
+		}
+
+		if ( ! isset( $rule_map[ $start_id ] ) ) {
+			return false;
+		}
+
+		$rule = $rule_map[ $start_id ];
+		$deps = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] ) ? $rule['base_includes'] : array();
+
+		foreach ( $deps as $dep_id ) {
+			if ( $dep_id === $start_id ) {
+				return true;
+			}
+			if ( in_array( $dep_id, $visited, true ) ) {
+				return true;
+			}
+			$path   = $visited;
+			$path[] = $dep_id;
+			if ( self::test_has_cycle( $rules, $dep_id, $path ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 }

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -462,14 +462,24 @@ class CFWC_Ajax {
 		$fees       = array();
 		$total_fees = 0;
 
-		// Filter rules for the specified country.
+		// Filter rules for the specified country (check both legacy and new format).
 		foreach ( $all_rules as $rule ) {
-			if ( isset( $rule['country'] ) && $rule['country'] === $country ) {
+			$rule_country = $rule['to_country'] ?? $rule['country'] ?? '';
+			if ( $rule_country === $country ) {
 				$fee_amount = 0;
+				$base       = $cart_total;
+
+				// Apply per-rule valuation method.
+				$valuation = $rule['valuation_method'] ?? 'inherit';
+				$global_method = get_option( 'cfwc_valuation_method', 'fob' );
+				$method    = ( 'inherit' !== $valuation ) ? $valuation : $global_method;
+				// Note: shipping proportion cannot be calculated without line-item
+				// context, so CIF is approximated by the caller providing a total
+				// that already includes shipping when desired.
 
 				// Calculate based on rule type.
 				if ( 'percentage' === $rule['type'] ) {
-					$fee_amount = ( $cart_total * $rule['rate'] ) / 100;
+					$fee_amount = ( $base * $rule['rate'] ) / 100;
 				} elseif ( 'flat' === $rule['type'] ) {
 					$fee_amount = $rule['amount'];
 				}

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -280,6 +280,17 @@ class CFWC_Ajax {
 			}
 		}
 
+		// Refuse a partial reorder: a stale or short order payload would
+		// silently drop the rules whose indices it omits, permanently
+		// deleting them from cfwc_rules.
+		if ( count( $reordered ) !== count( $rules ) ) {
+			wp_send_json_error(
+				array(
+					'message' => __( 'Invalid order data.', 'customs-fees-for-woocommerce' ),
+				)
+			);
+		}
+
 		// Save reordered rules.
 		update_option( 'cfwc_rules', $reordered );
 

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -98,8 +98,14 @@ class CFWC_Ajax {
 		// Update or add rule.
 		$updated = false;
 		if ( null !== $rule_id && isset( $rules[ $rule_id ] ) ) {
+			// Preserve the canonical rule_id from storage so a missing or
+			// stale client-supplied rule_id can't silently rotate the id and
+			// break other rules' base_includes references.
+			if ( ! empty( $rules[ $rule_id ]['rule_id'] ) ) {
+				$rule['rule_id'] = $rules[ $rule_id ]['rule_id'];
+			}
 			$rules[ $rule_id ] = $rule;
-			$updated = true;
+			$updated           = true;
 		} else {
 			// Try matching by rule_id string for existing rules.
 			foreach ( $rules as $index => $existing_rule ) {

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -123,10 +123,10 @@ class CFWC_Ajax {
 		// Clear cache.
 		CFWC_Calculator::clear_cache();
 
-		// Reset the cycle-error flag — the rule set just changed, so any
-		// previous dependency-error notice is stale and should be re-derived
-		// on the next calculator run rather than flashed against new data.
-		delete_transient( 'cfwc_rules_dependency_error' );
+		// Re-derive the cycle-error notice from the just-saved rules so the
+		// admin warning reflects the current state instead of waiting for a
+		// cart calculation to set or clear it.
+		CFWC_Calculator::refresh_cycle_notice( $rules );
 
 		wp_send_json_success(
 			array(
@@ -220,10 +220,10 @@ class CFWC_Ajax {
 			// Clear cache.
 			CFWC_Calculator::clear_cache();
 
-			// Reset the cycle-error flag — the rule set just changed, so any
-			// previous dependency-error notice is stale and should be re-derived
-			// on the next calculator run rather than flashed against new data.
-			delete_transient( 'cfwc_rules_dependency_error' );
+			// Re-derive the cycle-error notice from the just-saved rules so
+			// dropping a rule that broke a cycle clears the warning, and a
+			// remaining cycle keeps the warning visible.
+			CFWC_Calculator::refresh_cycle_notice( $rules );
 
 			wp_send_json_success(
 				array(
@@ -280,10 +280,10 @@ class CFWC_Ajax {
 		// Clear cache.
 		CFWC_Calculator::clear_cache();
 
-		// Reset the cycle-error flag — the rule set just changed, so any
-		// previous dependency-error notice is stale and should be re-derived
-		// on the next calculator run rather than flashed against new data.
-		delete_transient( 'cfwc_rules_dependency_error' );
+		// Re-derive the cycle-error notice. Reordering doesn't change
+		// dependencies, but running through the same code path keeps the
+		// transient state consistent with whatever is in storage.
+		CFWC_Calculator::refresh_cycle_notice( $reordered );
 
 		wp_send_json_success(
 			array(
@@ -474,10 +474,10 @@ class CFWC_Ajax {
 		// Clear cache.
 		CFWC_Calculator::clear_cache();
 
-		// Reset the cycle-error flag — the rule set just changed, so any
-		// previous dependency-error notice is stale and should be re-derived
-		// on the next calculator run rather than flashed against new data.
-		delete_transient( 'cfwc_rules_dependency_error' );
+		// Re-derive the cycle-error notice from the imported rule set so any
+		// cycles introduced (or resolved) by the CSV are reflected in admin
+		// without waiting for a cart calculation.
+		CFWC_Calculator::refresh_cycle_notice( $new_rules );
 
 		wp_send_json_success(
 			array(

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -123,6 +123,11 @@ class CFWC_Ajax {
 		// Clear cache.
 		CFWC_Calculator::clear_cache();
 
+		// Reset the cycle-error flag — the rule set just changed, so any
+		// previous dependency-error notice is stale and should be re-derived
+		// on the next calculator run rather than flashed against new data.
+		delete_transient( 'cfwc_rules_dependency_error' );
+
 		wp_send_json_success(
 			array(
 				'message' => __( 'Rule saved successfully.', 'customs-fees-for-woocommerce' ),
@@ -215,6 +220,11 @@ class CFWC_Ajax {
 			// Clear cache.
 			CFWC_Calculator::clear_cache();
 
+			// Reset the cycle-error flag — the rule set just changed, so any
+			// previous dependency-error notice is stale and should be re-derived
+			// on the next calculator run rather than flashed against new data.
+			delete_transient( 'cfwc_rules_dependency_error' );
+
 			wp_send_json_success(
 				array(
 					'message' => __( 'Rule deleted successfully.', 'customs-fees-for-woocommerce' ),
@@ -269,6 +279,11 @@ class CFWC_Ajax {
 
 		// Clear cache.
 		CFWC_Calculator::clear_cache();
+
+		// Reset the cycle-error flag — the rule set just changed, so any
+		// previous dependency-error notice is stale and should be re-derived
+		// on the next calculator run rather than flashed against new data.
+		delete_transient( 'cfwc_rules_dependency_error' );
 
 		wp_send_json_success(
 			array(
@@ -458,6 +473,11 @@ class CFWC_Ajax {
 
 		// Clear cache.
 		CFWC_Calculator::clear_cache();
+
+		// Reset the cycle-error flag — the rule set just changed, so any
+		// previous dependency-error notice is stale and should be re-derived
+		// on the next calculator run rather than flashed against new data.
+		delete_transient( 'cfwc_rules_dependency_error' );
 
 		wp_send_json_success(
 			array(

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -179,9 +179,35 @@ class CFWC_Ajax {
 
 		// Remove rule.
 		if ( null !== $rule_index && isset( $rules[ $rule_index ] ) ) {
+			$deleted_rule_id = isset( $rules[ $rule_index ]['rule_id'] ) ? $rules[ $rule_index ]['rule_id'] : '';
+
 			unset( $rules[ $rule_index ] );
 			// Re-index array.
 			$rules = array_values( $rules );
+
+			// Scrub the deleted rule_id from any other rule's base_includes so
+			// dependencies don't dangle after deletion. Without this, a rule
+			// that depended on the deleted one would keep referencing a
+			// non-existent id; the calculator silently drops missing deps but
+			// the merchant gets no signal that a dependency was broken.
+			if ( '' !== $deleted_rule_id ) {
+				foreach ( $rules as $i => $existing_rule ) {
+					if ( empty( $existing_rule['base_includes'] ) || ! is_array( $existing_rule['base_includes'] ) ) {
+						continue;
+					}
+					$filtered = array_values(
+						array_filter(
+							$existing_rule['base_includes'],
+							function ( $dep_id ) use ( $deleted_rule_id ) {
+								return $dep_id !== $deleted_rule_id;
+							}
+						)
+					);
+					if ( $filtered !== $existing_rule['base_includes'] ) {
+						$rules[ $i ]['base_includes'] = $filtered;
+					}
+				}
+			}
 
 			// Save rules.
 			update_option( 'cfwc_rules', $rules );

--- a/includes/admin/class-cfwc-onboarding.php
+++ b/includes/admin/class-cfwc-onboarding.php
@@ -178,7 +178,7 @@ class CFWC_Onboarding {
 					<?php esc_html_e( 'Configure Rules', 'customs-fees-for-woocommerce' ); ?>
 				</a>
 				
-				<a href="#" class="cfwc-dismiss-notice" style="margin-left: 15px;">
+				<a href="#" class="cfwc-dismiss-notice">
 					<?php esc_html_e( 'Close and don\'t show', 'customs-fees-for-woocommerce' ); ?>
 				</a>
 			</p>

--- a/includes/admin/views/rules-section.php
+++ b/includes/admin/views/rules-section.php
@@ -701,15 +701,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<div class="cfwc-rules-table-wrapper">
 		<table class="widefat fixed striped cfwc-rules-table">
 			<thead>
-				<tr>
-					<th style="width: 18%;"><?php esc_html_e( 'Label', 'customs-fees-for-woocommerce' ); ?></th>
-					<th style="width: 18%;"><?php esc_html_e( 'Countries', 'customs-fees-for-woocommerce' ); ?></th>
-					<th style="width: 18%;"><?php esc_html_e( 'Products', 'customs-fees-for-woocommerce' ); ?></th>
-					<th style="width: 12%;"><?php esc_html_e( 'Type', 'customs-fees-for-woocommerce' ); ?></th>
-					<th style="width: 7%;"><?php esc_html_e( 'Rate', 'customs-fees-for-woocommerce' ); ?></th>
-					<th style="width: 12%;"><?php esc_html_e( 'Stacking', 'customs-fees-for-woocommerce' ); ?></th>
-					<th style="width: 15%;"><?php esc_html_e( 'Actions', 'customs-fees-for-woocommerce' ); ?></th>
-				</tr>
+					<tr>
+						<th style="width: 15%;"><?php esc_html_e( 'Label', 'customs-fees-for-woocommerce' ); ?></th>
+						<th style="width: 15%;"><?php esc_html_e( 'Countries', 'customs-fees-for-woocommerce' ); ?></th>
+						<th style="width: 15%;"><?php esc_html_e( 'Products', 'customs-fees-for-woocommerce' ); ?></th>
+						<th style="width: 10%;"><?php esc_html_e( 'Type', 'customs-fees-for-woocommerce' ); ?></th>
+						<th style="width: 7%;"><?php esc_html_e( 'Rate', 'customs-fees-for-woocommerce' ); ?></th>
+						<th style="width: 10%;"><?php esc_html_e( 'Valuation', 'customs-fees-for-woocommerce' ); ?></th>
+						<th style="width: 10%;"><?php esc_html_e( 'Depends on', 'customs-fees-for-woocommerce' ); ?></th>
+						<th style="width: 10%;"><?php esc_html_e( 'Stacking', 'customs-fees-for-woocommerce' ); ?></th>
+						<th style="width: 8%;"><?php esc_html_e( 'Actions', 'customs-fees-for-woocommerce' ); ?></th>
+					</tr>
 			</thead>
 			<tbody id="cfwc-rules-tbody">
 				<?php if ( ! empty( $rules ) ) : ?>
@@ -814,8 +816,44 @@ if ( ! defined( 'ABSPATH' ) ) {
 									echo wp_kses_post( wc_price( $rule['amount'] ?? 0 ) );
 								}
 								?>
-							</td>
-							<td>
+								</td>
+								<td>
+									<?php
+									$valuation_method = $rule['valuation_method'] ?? 'inherit';
+									$valuation_labels = array(
+										'fob'           => __( 'FOB', 'customs-fees-for-woocommerce' ),
+										'cif'           => __( 'CIF', 'customs-fees-for-woocommerce' ),
+										'cif_insurance' => __( 'CIF + Ins', 'customs-fees-for-woocommerce' ),
+									);
+									if ( 'inherit' !== $valuation_method ) {
+										echo '<span style="display: inline-block; padding: 3px 8px; background: #2271b1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' . esc_attr__( 'Overrides global valuation', 'customs-fees-for-woocommerce' ) . '">' . esc_html( $valuation_labels[ $valuation_method ] ?? $valuation_method ) . '</span>';
+									} else {
+										echo '<em style="color: #999; font-size: 11px;">' . esc_html__( 'Global', 'customs-fees-for-woocommerce' ) . '</em>';
+									}
+									?>
+								</td>
+								<td>
+									<?php
+									$base_includes = $rule['base_includes'] ?? array();
+									if ( ! empty( $base_includes ) ) {
+										$count  = count( $base_includes );
+										$labels = array();
+										foreach ( $base_includes as $dep_id ) {
+											foreach ( $rules as $r ) {
+												if ( isset( $r['rule_id'] ) && $r['rule_id'] === $dep_id ) {
+													$labels[] = $r['label'] ?? $dep_id;
+													break;
+												}
+											}
+										}
+										$title = esc_attr( implode( ', ', $labels ) );
+										echo '<span style="display: inline-block; padding: 3px 8px; background: #8261a1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' . $title . '">+' . esc_html( $count ) . ' fee(s)</span>';
+									} else {
+										echo '<em style="color: #999; font-size: 11px;">-</em>';
+									}
+									?>
+								</td>
+								<td>
 								<?php
 								$stacking_mode = $rule['stacking_mode'] ?? 'add';
 
@@ -860,7 +898,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php endforeach; ?>
 				<?php else : ?>
 					<tr class="no-rules">
-						<td colspan="7"><?php esc_html_e( 'No rules configured. Use the preset loader above or add rules manually.', 'customs-fees-for-woocommerce' ); ?></td>
+						<td colspan="9"><?php esc_html_e( 'No rules configured. Use the preset loader above or add rules manually.', 'customs-fees-for-woocommerce' ); ?></td>
 					</tr>
 				<?php endif; ?>
 			</tbody>

--- a/includes/admin/views/rules-section.php
+++ b/includes/admin/views/rules-section.php
@@ -97,7 +97,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</label>
 				</th>
 				<td class="forminp">
-					<select id="cfwc_default_origin_select" name="cfwc_default_origin_select" class="wc-enhanced-select" style="width: 350px; max-width: 50%;">
+					<select id="cfwc_default_origin_select" name="cfwc_default_origin_select" class="wc-enhanced-select">
 						<option value="store" <?php selected( $selected_origin, 'store' ); ?>>
 							<?php
 							printf(
@@ -160,19 +160,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<label>
 							<input type="radio" name="cfwc_valuation_method" value="fob" <?php checked( $valuation_method, 'fob' ); ?> />
 							<strong><?php esc_html_e( 'FOB - Product Value Only', 'customs-fees-for-woocommerce' ); ?></strong>
-							<span class="description" style="display: block; margin: 2px 0 8px 24px; color: #666;">
+							<span class="description cfwc-default-origin-help">
 								<?php esc_html_e( 'Calculate customs fees based on product prices only. Used by USA, Canada.', 'customs-fees-for-woocommerce' ); ?>
 							</span>
 						</label>
 						<label>
 							<input type="radio" name="cfwc_valuation_method" value="cif" <?php checked( $valuation_method, 'cif' ); ?> />
 							<strong><?php esc_html_e( 'CIF - Include Shipping in Customs Value', 'customs-fees-for-woocommerce' ); ?></strong>
-							<span class="description" style="display: block; margin: 2px 0 8px 24px; color: #666;">
+							<span class="description cfwc-default-origin-help">
 								<?php esc_html_e( 'Include shipping costs in the customs value calculation. Used by EU, UK, Australia, Japan, and most other countries.', 'customs-fees-for-woocommerce' ); ?>
 							</span>
 						</label>
-						<p class="description" style="margin-top: 10px;">
-							<span class="dashicons dashicons-info" style="color: #2271b1;"></span>
+						<p class="description cfwc-help-link-under">
+							<span class="dashicons dashicons-info"></span>
 							<?php esc_html_e( 'When CIF is selected, shipping costs are distributed proportionally across products based on their value.', 'customs-fees-for-woocommerce' ); ?>
 						</p>
 					</fieldset>
@@ -186,7 +186,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<input type="hidden" name="cfwc_custom_default_origin" id="cfwc_custom_default_origin" value="<?php echo esc_attr( $custom_origin ); ?>" />
 	
 	<!-- WooCommerce Style Modal for Help -->
-	<div id="cfwc-help-modal" class="cfwc-modal" style="display: none;">
+	<div id="cfwc-help-modal" class="cfwc-modal" hidden>
 		<div class="cfwc-modal-backdrop"></div>
 		<div class="cfwc-modal-content">
 			<div class="cfwc-modal-header">
@@ -200,7 +200,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<!-- How It Works -->
 				<div class="cfwc-help-section">
 					<h3>
-						<span class="dashicons dashicons-info" style="color: #2271b1;"></span>
+						<span class="dashicons dashicons-info"></span>
 						<?php esc_html_e( 'How it works', 'customs-fees-for-woocommerce' ); ?>
 					</h3>
 					<ol>
@@ -214,7 +214,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<!-- How Rules Apply -->
 				<div class="cfwc-help-section">
 					<h3>
-						<span class="dashicons dashicons-admin-generic" style="color: #2271b1;"></span>
+						<span class="dashicons dashicons-admin-generic"></span>
 						<?php esc_html_e( 'How rules apply', 'customs-fees-for-woocommerce' ); ?>
 					</h3>
 					<ul>
@@ -227,7 +227,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<!-- Pro Tips -->
 				<div class="cfwc-help-section">
 					<h3>
-						<span class="dashicons dashicons-lightbulb" style="color: #f0ad4e;"></span>
+						<span class="dashicons dashicons-lightbulb"></span>
 						<?php esc_html_e( 'Pro tips', 'customs-fees-for-woocommerce' ); ?>
 					</h3>
 					<ul>
@@ -241,7 +241,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<!-- Rule Stacking Modes -->
 				<div class="cfwc-help-section">
 					<h3>
-						<span class="dashicons dashicons-admin-settings" style="color: #2271b1;"></span>
+						<span class="dashicons dashicons-admin-settings"></span>
 						<?php esc_html_e( 'Rule stacking modes', 'customs-fees-for-woocommerce' ); ?>
 					</h3>
 					<div class="cfwc-stacking-modes">
@@ -269,172 +269,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	</div>
 	
-	<style>
-	/* WooCommerce-style Modal */
-	.cfwc-modal {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		z-index: 160000;
-	}
-	
-	.cfwc-modal-backdrop {
-		position: fixed;
-		top: 0;
-		left: 0;
-		right: 0;
-		bottom: 0;
-		background: rgba(0, 0, 0, 0.6);
-		z-index: 159990;
-	}
-	
-	.cfwc-modal-content {
-		position: absolute;
-		top: 50%;
-		left: 50%;
-		transform: translate(-50%, -50%);
-		width: 90%;
-		max-width: 600px;
-		max-height: 90vh;
-		background: #fff;
-		border-radius: 4px;
-		box-shadow: 0 3px 30px rgba(0, 0, 0, 0.2);
-		z-index: 160000;
-		display: flex;
-		flex-direction: column;
-	}
-	
-	.cfwc-modal-header {
-		padding: 20px;
-		border-bottom: 1px solid #e0e0e0;
-		display: flex;
-		justify-content: space-between;
-		align-items: center;
-	}
-	
-	.cfwc-modal-header h2 {
-		margin: 0;
-		font-size: 18px;
-		font-weight: 600;
-		color: #333;
-	}
-	
-	.cfwc-modal-close {
-		background: none;
-		border: none;
-		cursor: pointer;
-		padding: 0;
-		color: #999;
-		font-size: 20px;
-	}
-	
-	.cfwc-modal-close:hover {
-		color: #333;
-	}
-	
-	.cfwc-modal-body {
-		padding: 20px;
-		overflow-y: auto;
-		flex: 1;
-	}
-	
-	.cfwc-modal-footer {
-		padding: 20px;
-		border-top: 1px solid #e0e0e0;
-		text-align: right;
-	}
-	
-	.cfwc-help-section {
-		margin-bottom: 30px;
-	}
-	
-	.cfwc-help-section:last-child {
-		margin-bottom: 0;
-	}
-	
-	.cfwc-help-section h3 {
-		margin: 0 0 15px 0;
-		font-size: 14px;
-		font-weight: 600;
-		color: #333;
-	}
-	
-	.cfwc-help-section h3 .dashicons {
-		font-size: 18px;
-		vertical-align: middle;
-		margin-right: 5px;
-	}
-	
-	.cfwc-help-section ol,
-	.cfwc-help-section ul {
-		margin: 0;
-		padding-left: 25px;
-		font-size: 14px;
-		line-height: 1.8;
-		color: #555;
-	}
-	
-	.cfwc-help-section li {
-		margin-bottom: 8px;
-	}
-	
-	.cfwc-stacking-modes {
-		margin-top: 10px;
-	}
-	
-	.cfwc-stacking-mode {
-		margin-bottom: 10px;
-		display: flex;
-		align-items: center;
-		gap: 10px;
-	}
-	
-	.cfwc-badge {
-		display: inline-block;
-		padding: 4px 10px;
-		border-radius: 3px;
-		font-size: 12px;
-		font-weight: 600;
-		color: #fff;
-		min-width: 70px;
-		text-align: center;
-	}
-	
-	.cfwc-badge-stack {
-		background: #46b450;
-	}
-	
-	.cfwc-badge-override {
-		background: #f0ad4e;
-	}
-	
-	.cfwc-badge-exclusive {
-		background: #dc3232;
-	}
-	
-	/* Mobile styles */
-	@media screen and (max-width: 768px) {
-		.cfwc-modal-content {
-			width: 100%;
-			height: 100%;
-			max-width: none;
-			max-height: none;
-			border-radius: 0;
-			transform: none;
-			position: fixed;
-			top: 0;
-			left: 0;
-		}
-		
-		#cfwc_default_origin_select {
-			width: 100% !important;
-			margin-left: 0 !important;
-			margin-top: 10px;
-		}
-	}
-	</style>
 	
 	<script>
 	jQuery(document).ready(function($) {
@@ -565,7 +399,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<h3><?php esc_html_e( 'Quick Start with Presets', 'customs-fees-for-woocommerce' ); ?></h3>
 		<p><?php esc_html_e( 'Load presets to quickly configure common import scenarios:', 'customs-fees-for-woocommerce' ); ?></p>
 		
-		<select id="cfwc-preset-select" class="wc-enhanced-select" style="width: 280px; max-width: 100%;">
+		<select id="cfwc-preset-select" class="wc-enhanced-select">
 			<option value=""><?php esc_html_e( '-- Select a preset --', 'customs-fees-for-woocommerce' ); ?></option>
 			<?php if ( ! empty( $templates ) ) : ?>
 				<?php foreach ( $templates as $template_id => $template ) : ?>
@@ -595,7 +429,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 	</div>
 	
-	<div style="margin: 40px 0 30px 0; border-top: 1px solid #c3c4c7;"></div>
+	<div class="cfwc-rules-divider"></div>
 	
 	<!-- Mixed Rules Warning -->
 	<?php
@@ -653,7 +487,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	// Display all collected notices in one area.
 	if ( ! empty( $notices ) ) :
 		?>
-		<div class="cfwc-notices-container" style="margin-bottom: 20px;">
+		<div class="cfwc-notices-container">
 			<?php foreach ( $notices as $notice ) : ?>
 				<?php
 				$is_dismissible = ! empty( $notice['dismissible'] );
@@ -663,7 +497,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					$notice_class .= ' is-dismissible cfwc-dismissible-notice';
 				}
 				?>
-				<div class="<?php echo esc_attr( $notice_class ); ?>" style="margin-bottom: 10px;" <?php echo $dismiss_key ? 'data-dismiss-key="' . esc_attr( $dismiss_key ) . '"' : ''; ?>>
+				<div class="<?php echo esc_attr( $notice_class ); ?>" <?php echo $dismiss_key ? 'data-dismiss-key="' . esc_attr( $dismiss_key ) . '"' : ''; ?>>
 					<p><?php echo wp_kses_post( $notice['content'] ); ?></p>
 					<?php if ( $is_dismissible ) : ?>
 						<button type="button" class="notice-dismiss cfwc-notice-dismiss">
@@ -679,9 +513,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	
 	<!-- Rules Table -->
 	<div class="cfwc-rules-header">
-		<div style="flex: 1;">
-			<div style="display: flex; align-items: center; gap: 10px; margin-bottom: 10px;">
-				<h3 style="margin: 0;"><?php esc_html_e( 'All Rules', 'customs-fees-for-woocommerce' ); ?></h3>
+		<div class="cfwc-rules-header-info">
+			<div class="cfwc-rules-header-title">
+				<h3><?php esc_html_e( 'All Rules', 'customs-fees-for-woocommerce' ); ?></h3>
 				<button type="button" class="button cfwc-add-rule">
 					<?php esc_html_e( 'Add New Rule', 'customs-fees-for-woocommerce' ); ?>
 				</button>
@@ -689,9 +523,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php esc_html_e( 'Delete All Rules', 'customs-fees-for-woocommerce' ); ?>
 				</button>
 			</div>
-			<p style="margin: 0;"><?php esc_html_e( 'Configure customs fee rules based on destination countries, product origins, categories, and HS codes.', 'customs-fees-for-woocommerce' ); ?></p>
+			<p><?php esc_html_e( 'Configure customs fee rules based on destination countries, product origins, categories, and HS codes.', 'customs-fees-for-woocommerce' ); ?></p>
 		</div>
-		<div style="align-self: flex-start;">
+		<div class="cfwc-rules-header-actions">
 			<a href="#" id="cfwc-help-link" class="cfwc-help-link-under">
 				<span class="cfwc-help-text"><?php esc_html_e( 'Need help getting started?', 'customs-fees-for-woocommerce' ); ?></span>
 			</a>
@@ -702,15 +536,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<table class="widefat fixed striped cfwc-rules-table">
 			<thead>
 					<tr>
-						<th style="width: 15%;"><?php esc_html_e( 'Label', 'customs-fees-for-woocommerce' ); ?></th>
-						<th style="width: 15%;"><?php esc_html_e( 'Countries', 'customs-fees-for-woocommerce' ); ?></th>
-						<th style="width: 15%;"><?php esc_html_e( 'Products', 'customs-fees-for-woocommerce' ); ?></th>
-						<th style="width: 10%;"><?php esc_html_e( 'Type', 'customs-fees-for-woocommerce' ); ?></th>
-						<th style="width: 7%;"><?php esc_html_e( 'Rate', 'customs-fees-for-woocommerce' ); ?></th>
-						<th style="width: 10%;"><?php esc_html_e( 'Valuation', 'customs-fees-for-woocommerce' ); ?></th>
-						<th style="width: 10%;"><?php esc_html_e( 'Depends on', 'customs-fees-for-woocommerce' ); ?></th>
-						<th style="width: 10%;"><?php esc_html_e( 'Stacking', 'customs-fees-for-woocommerce' ); ?></th>
-						<th style="width: 8%;"><?php esc_html_e( 'Actions', 'customs-fees-for-woocommerce' ); ?></th>
+						<th class="cfwc-col-label"><?php esc_html_e( 'Label', 'customs-fees-for-woocommerce' ); ?></th>
+						<th class="cfwc-col-countries"><?php esc_html_e( 'Countries', 'customs-fees-for-woocommerce' ); ?></th>
+						<th class="cfwc-col-products"><?php esc_html_e( 'Products', 'customs-fees-for-woocommerce' ); ?></th>
+						<th class="cfwc-col-type"><?php esc_html_e( 'Type', 'customs-fees-for-woocommerce' ); ?></th>
+						<th class="cfwc-col-rate"><?php esc_html_e( 'Rate', 'customs-fees-for-woocommerce' ); ?></th>
+						<th class="cfwc-col-valuation"><?php esc_html_e( 'Valuation', 'customs-fees-for-woocommerce' ); ?></th>
+						<th class="cfwc-col-depends"><?php esc_html_e( 'Depends on', 'customs-fees-for-woocommerce' ); ?></th>
+						<th class="cfwc-col-stacking"><?php esc_html_e( 'Stacking', 'customs-fees-for-woocommerce' ); ?></th>
+						<th class="cfwc-col-actions"><?php esc_html_e( 'Actions', 'customs-fees-for-woocommerce' ); ?></th>
 					</tr>
 			</thead>
 			<tbody id="cfwc-rules-tbody">
@@ -724,8 +558,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 								// Match JavaScript rendering for priority.
 								$priority = $rule['priority'] ?? 0;
 								if ( $priority > 0 ) {
-									echo ' <span style="color: #666; font-size: 11px;">(' . esc_html( $priority ) .
-										' <span class="dashicons dashicons-info" style="font-size: 14px; vertical-align: middle; cursor: help;" ' .
+									echo ' <span class="cfwc-priority-meta">(' . esc_html( $priority ) .
+										' <span class="dashicons dashicons-info" ' .
 										'title="' . esc_attr__( 'Higher priority rules are checked first (0-100)', 'customs-fees-for-woocommerce' ) . '"></span>)</span>';
 								}
 								?>
@@ -784,21 +618,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 												$cat_names[] = sprintf( __( '+%d more', 'customs-fees-for-woocommerce' ), count( $cat_ids ) - 2 );
 											}
 											if ( ! empty( $cat_names ) ) {
-												$criteria[] = '<span class="dashicons dashicons-category" style="font-size: 14px;"></span> ' . implode( ', ', $cat_names );
+												$criteria[] = '<span class="dashicons dashicons-category cfwc-criteria-icon"></span> ' . implode( ', ', $cat_names );
 											}
 										}
 									}
 
 									// HS Code.
 									if ( ! empty( $rule['hs_code_pattern'] ) ) {
-										$criteria[] = '<span class="dashicons dashicons-tag" style="font-size: 14px;"></span> HS: ' . esc_html( $rule['hs_code_pattern'] );
+										$criteria[] = '<span class="dashicons dashicons-tag cfwc-criteria-icon"></span> HS: ' . esc_html( $rule['hs_code_pattern'] );
 									}
 
 									// Output criteria with allowed HTML (dashicons and breaks).
 									$allowed_html = array(
 										'span' => array(
 											'class' => array(),
-											'style' => array(),
 										),
 										'br'   => array(),
 										'em'   => array(),
@@ -826,9 +659,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 										'cif_insurance' => __( 'CIF + Ins', 'customs-fees-for-woocommerce' ),
 									);
 									if ( 'inherit' !== $valuation_method ) {
-										echo '<span style="display: inline-block; padding: 3px 8px; background: #2271b1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' . esc_attr__( 'Overrides global valuation', 'customs-fees-for-woocommerce' ) . '">' . esc_html( $valuation_labels[ $valuation_method ] ?? $valuation_method ) . '</span>';
+										echo '<span class="cfwc-rule-badge cfwc-rule-badge--valuation" title="' . esc_attr__( 'Overrides global valuation', 'customs-fees-for-woocommerce' ) . '">' . esc_html( $valuation_labels[ $valuation_method ] ?? $valuation_method ) . '</span>';
 									} else {
-										echo '<em style="color: #999; font-size: 11px;">' . esc_html__( 'Global', 'customs-fees-for-woocommerce' ) . '</em>';
+										echo '<em class="cfwc-empty-cell">' . esc_html__( 'Global', 'customs-fees-for-woocommerce' ) . '</em>';
 									}
 									?>
 								</td>
@@ -852,9 +685,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 											_n( '+%s fee', '+%s fees', $count, 'customs-fees-for-woocommerce' ),
 											number_format_i18n( $count )
 										);
-										echo '<span style="display: inline-block; padding: 3px 8px; background: #8261a1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' . $title . '">' . esc_html( $badge_label ) . '</span>';
+										echo '<span class="cfwc-rule-badge cfwc-rule-badge--dependency" title="' . esc_attr( $title ) . '">' . esc_html( $badge_label ) . '</span>';
 									} else {
-										echo '<em style="color: #999; font-size: 11px;">-</em>';
+										echo '<em class="cfwc-empty-cell">-</em>';
 									}
 									?>
 								</td>
@@ -869,24 +702,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 									'exclusive' => __( 'Exclusive', 'customs-fees-for-woocommerce' ),
 								);
 
-								$stacking_colors = array(
-									'add'       => '#46b450',
-									'override'  => '#f0ad4e',
-									'exclusive' => '#dc3232',
-								);
-
 								$stacking_descriptions = array(
 									'add'       => __( 'Adds with other matching rules', 'customs-fees-for-woocommerce' ),
 									'override'  => __( 'Replaces lower priority rules', 'customs-fees-for-woocommerce' ),
 									'exclusive' => __( 'Only this rule applies', 'customs-fees-for-woocommerce' ),
 								);
 
-								// Output WooCommerce-style badge.
-								$badge_color = $stacking_colors[ $stacking_mode ] ?? $stacking_colors['add'];
-								$badge_label = $stacking_labels[ $stacking_mode ] ?? $stacking_labels['add'];
-								$badge_title = $stacking_descriptions[ $stacking_mode ] ?? $stacking_descriptions['add'];
+								$mode_key    = isset( $stacking_labels[ $stacking_mode ] ) ? $stacking_mode : 'add';
+								$badge_label = $stacking_labels[ $mode_key ];
+								$badge_title = $stacking_descriptions[ $mode_key ];
 
-								echo '<span style="display: inline-block; padding: 3px 8px; background: ' . esc_attr( $badge_color ) . '; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' . esc_attr( $badge_title ) . '">';
+								echo '<span class="cfwc-rule-badge cfwc-rule-badge--stacking-' . esc_attr( $mode_key ) . '" title="' . esc_attr( $badge_title ) . '">';
 								echo esc_html( $badge_label );
 								echo '</span>';
 								?>

--- a/includes/admin/views/rules-section.php
+++ b/includes/admin/views/rules-section.php
@@ -97,7 +97,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</label>
 				</th>
 				<td class="forminp">
-					<select id="cfwc_default_origin_select" name="cfwc_default_origin_select" class="wc-enhanced-select">
+					<select id="cfwc_default_origin_select" name="cfwc_default_origin_select" class="wc-enhanced-select cfwc-select2-field">
 						<option value="store" <?php selected( $selected_origin, 'store' ); ?>>
 							<?php
 							printf(
@@ -399,7 +399,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<h3><?php esc_html_e( 'Quick Start with Presets', 'customs-fees-for-woocommerce' ); ?></h3>
 		<p><?php esc_html_e( 'Load presets to quickly configure common import scenarios:', 'customs-fees-for-woocommerce' ); ?></p>
 		
-		<select id="cfwc-preset-select" class="wc-enhanced-select">
+		<select id="cfwc-preset-select" class="wc-enhanced-select cfwc-select2-field">
 			<option value=""><?php esc_html_e( '-- Select a preset --', 'customs-fees-for-woocommerce' ); ?></option>
 			<?php if ( ! empty( $templates ) ) : ?>
 				<?php foreach ( $templates as $template_id => $template ) : ?>

--- a/includes/admin/views/rules-section.php
+++ b/includes/admin/views/rules-section.php
@@ -550,7 +550,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<tbody id="cfwc-rules-tbody">
 				<?php if ( ! empty( $rules ) ) : ?>
 					<?php foreach ( $rules as $index => $rule ) : ?>
-						<tr>
+						<tr class="cfwc-rule-row">
 							<td>
 								<?php
 								echo esc_html( $rule['label'] ?? '' );

--- a/includes/admin/views/rules-section.php
+++ b/includes/admin/views/rules-section.php
@@ -846,8 +846,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 												}
 											}
 										}
-										$title = esc_attr( implode( ', ', $labels ) );
-										echo '<span style="display: inline-block; padding: 3px 8px; background: #8261a1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' . $title . '">+' . esc_html( $count ) . ' fee(s)</span>';
+										$title       = esc_attr( implode( ', ', $labels ) );
+										$badge_label = sprintf(
+											/* translators: %s: count of dependency fees included in the base */
+											_n( '+%s fee', '+%s fees', $count, 'customs-fees-for-woocommerce' ),
+											number_format_i18n( $count )
+										);
+										echo '<span style="display: inline-block; padding: 3px 8px; background: #8261a1; color: #fff; border-radius: 3px; font-size: 11px; font-weight: 600; line-height: 1;" title="' . $title . '">' . esc_html( $badge_label ) . '</span>';
 									} else {
 										echo '<em style="color: #999; font-size: 11px;">-</em>';
 									}

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -842,7 +842,7 @@ class CFWC_Calculator {
 	 * @param array  $visited    Already visited rule IDs.
 	 * @return bool True if a cycle is detected.
 	 */
-	private function has_cycle( $rules, $start_id, $visited = array() ) {
+	public function has_cycle( $rules, $start_id, $visited = array() ) {
 		$rule_map = array();
 		foreach ( $rules as $rule ) {
 			$rid = isset( $rule['rule_id'] ) ? $rule['rule_id'] : '';

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -311,7 +311,7 @@ class CFWC_Calculator {
 			$cycle_rule_ids = array();
 			foreach ( $matching_rules as $cr ) {
 				$cr_id = isset( $cr['rule_id'] ) && '' !== $cr['rule_id'] ? $cr['rule_id'] : '';
-				if ( '' !== $cr_id && $this->has_cycle( $matching_rules, $cr_id ) ) {
+				if ( '' !== $cr_id && self::has_cycle( $matching_rules, $cr_id ) ) {
 					$cycle_labels[]            = $cr['label'] ?? $cr_id;
 					$cycle_rule_ids[ $cr_id ] = true;
 				}
@@ -829,7 +829,7 @@ class CFWC_Calculator {
 	 * @param array  $visited    Already visited rule IDs.
 	 * @return bool True if a cycle is detected.
 	 */
-	public function has_cycle( $rules, $start_id, $visited = array() ) {
+	public static function has_cycle( $rules, $start_id, $visited = array() ) {
 		$rule_map = array();
 		foreach ( $rules as $rule ) {
 			$rid = isset( $rule['rule_id'] ) ? $rule['rule_id'] : '';
@@ -854,7 +854,7 @@ class CFWC_Calculator {
 			}
 			$path   = $visited;
 			$path[] = $dep_id;
-			if ( $this->has_cycle( $rules, $dep_id, $path ) ) {
+			if ( self::has_cycle( $rules, $dep_id, $path ) ) {
 				return true;
 			}
 		}
@@ -1101,9 +1101,7 @@ class CFWC_Calculator {
 	 *
 	 * @since 1.0.0
 	 */
-	public function clear_cache() {
-		$this->rules_cache = null;
-
+	public static function clear_cache() {
 		// Clear any transients.
 		delete_transient( 'cfwc_rules_cache' );
 

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -499,6 +499,7 @@ class CFWC_Calculator {
 					break;
 				}
 			}
+		}
 
 		// Convert grouped fees to array and update labels with count.
 		$fees = array();

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -224,9 +224,6 @@ class CFWC_Calculator {
 				$line_total = $cart_item['line_total'];
 			}
 
-			// Apply customs valuation method (CIF support).
-			$line_total = $this->apply_valuation_method( $line_total, $cart_item, $cart );
-
 			// Get HS code using centralized helper.
 			if ( class_exists( 'CFWC_Products_Variation_Support' ) ) {
 				$customs_data = CFWC_Products_Variation_Support::get_product_customs_data( $product );
@@ -240,6 +237,7 @@ class CFWC_Calculator {
 					$hs_code = get_post_meta( $product->get_parent_id(), '_cfwc_hs_code', true );
 				}
 			}
+
 			// Determine price mode for logging.
 			$price_mode = ( 'yes' === $use_original_price ) ? 'Original Price' : 'Discounted Price';
 			$this->log_debug(
@@ -281,7 +279,7 @@ class CFWC_Calculator {
 					if ( 'all' === $match_type &&
 						$rule_from === $origin &&
 						$rule_to === $destination_country ) {
-						$rule['rule_id']  = $rule_id;
+						$rule['rule_id']  = isset( $rule['rule_id'] ) ? $rule['rule_id'] : (string) $rule_id;
 						$matching_rules[] = $rule;
 						$this->log_debug(
 							sprintf(
@@ -299,54 +297,204 @@ class CFWC_Calculator {
 				}
 			}
 
-			// Process matching rules for this product.
-			foreach ( $matching_rules as $rule ) {
-				$fee = $this->calculate_single_fee( $rule, $line_total );
-				if ( false !== $fee && $fee > 0 ) {
-					$base_label = $this->get_fee_label( $rule, $destination_country, $origin );
-
-					// Check if the label already contains a percentage (e.g., "(50%)").
-					$has_percentage = preg_match( '/\(\d+(?:\.\d+)?%\)/', $base_label );
-
-					// Add percentage rate in brackets only if not already present and it's a percentage rule.
-					if ( ! $has_percentage && isset( $rule['type'] ) && 'percentage' === $rule['type'] && ! empty( $rule['rate'] ) ) {
-						$label = sprintf( '%s (%s%%)', $base_label, $rule['rate'] );
-					} else {
-						// For flat rate or if percentage already in label, just use the base label.
-						$label = $base_label;
-					}
-
-					// Create a unique key for grouping that includes the base label and rate.
-					$group_key = $base_label . '|' . ( $rule['type'] ?? 'flat' ) . '|' . ( $rule['rate'] ?? '0' );
-
-					// Group fees by rule for consolidation.
-					if ( ! isset( $fees_by_label[ $group_key ] ) ) {
-						$fees_by_label[ $group_key ] = array(
-							'base_label' => $base_label,
-							'label'      => $label,
-							'amount'     => 0,
-							'count'      => 0,
-							'rate'       => $rule['rate'] ?? '',
-							'type'       => $rule['type'] ?? 'flat',
-							'taxable'    => $this->is_fee_taxable( $rule ),
-							'tax_class'  => $this->get_fee_tax_class( $rule ),
-						);
-					}
-
-					$fees_by_label[ $group_key ]['amount'] += $fee;
-					++$fees_by_label[ $group_key ]['count'];
-
-					// Log fee application.
-					$this->log_debug(
-						sprintf(
-							'      Applied: %s = $%.2f',
-							$label,
-							$fee
-						)
-					);
+			// Build rule ID map for dependency resolution.
+			$id_to_rule = array();
+			foreach ( $matching_rules as $mr ) {
+				$rid = isset( $mr['rule_id'] ) && '' !== $mr['rule_id'] ? $mr['rule_id'] : '';
+				if ( '' !== $rid ) {
+					$id_to_rule[ $rid ] = $mr;
 				}
 			}
-		}
+
+			// Round-based dependency resolution for matching rules.
+			$calculated = array(); // rule_id => fee amount.
+			$pending    = $matching_rules;
+			$rounds     = 0;
+			$max_rounds = count( $matching_rules ) + 1;
+
+			while ( ! empty( $pending ) && $rounds < $max_rounds ) {
+				++$rounds;
+				$made_progress = false;
+				$still_pending = array();
+
+				foreach ( $pending as $rule ) {
+					$rule_id = isset( $rule['rule_id'] ) && '' !== $rule['rule_id'] ? $rule['rule_id'] : (string) array_search( $rule, $matching_rules, true );
+					if ( '' === $rule_id ) {
+						$rule_id = 'rule_' . wp_rand( 1000, 9999 );
+					}
+
+					$deps = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] )
+						? $rule['base_includes']
+						: array();
+
+					// Filter deps to only those that actually matched.
+					$deps = array_filter(
+						$deps,
+						function ( $dep_id ) use ( $id_to_rule ) {
+							return isset( $id_to_rule[ $dep_id ] );
+						}
+					);
+
+					// Check if all deps are already calculated.
+					$deps_ready = true;
+					foreach ( $deps as $dep_id ) {
+						if ( ! isset( $calculated[ $dep_id ] ) ) {
+							$deps_ready = false;
+							break;
+						}
+					}
+
+					if ( $deps_ready ) {
+						// Apply valuation method per-rule.
+						$customs_value = $this->apply_valuation_method( $line_total, $cart_item, $cart, $rule );
+
+						// Add included fees from dependencies.
+						foreach ( $deps as $dep_id ) {
+							// Self-reference protection.
+							if ( $dep_id === $rule_id ) {
+								continue;
+							}
+							// Cycle detection.
+							if ( $this->has_cycle( $matching_rules, $rule_id ) ) {
+								$this->log_debug(
+									sprintf(
+										'    WARNING: Cycle detected in base_includes for rule "%s". Skipping dependency fees.',
+										$rule['label'] ?? $rule_id
+									),
+									'warning'
+								);
+								if ( function_exists( 'wc_get_logger' ) ) {
+									wc_get_logger()->warning(
+										sprintf(
+											'Cycle detected in customs fee rule dependencies: %s',
+											$rule['label'] ?? $rule_id
+										),
+										array( 'source' => 'customs-fees' )
+									);
+								}
+								// Set admin notice transient.
+								$cycle_labels = array();
+								foreach ( $matching_rules as $r ) {
+									if ( $this->has_cycle( $matching_rules, $r['rule_id'] ?? '' ) ) {
+										$cycle_labels[] = $r['label'] ?? ( $r['rule_id'] ?? '' );
+									}
+								}
+								if ( ! empty( $cycle_labels ) ) {
+									set_transient( 'cfwc_rules_dependency_error', array_unique( $cycle_labels ), DAY_IN_SECONDS );
+								}
+								break;
+							}
+							$customs_value += $calculated[ $dep_id ];
+						}
+
+						$fee = $this->calculate_single_fee( $rule, $customs_value );
+
+						if ( false !== $fee && $fee > 0 ) {
+							$calculated[ $rule_id ] = $fee;
+
+							$base_label = $this->get_fee_label( $rule, $destination_country, $origin );
+
+							// Check if the label already contains a percentage (e.g., "(50%)").
+							$has_percentage = preg_match( '/\(\d+(?:\.\d+)?%\)/', $base_label );
+
+							// Add percentage rate in brackets only if not already present and it's a percentage rule.
+							if ( ! $has_percentage && isset( $rule['type'] ) && 'percentage' === $rule['type'] && ! empty( $rule['rate'] ) ) {
+								$label = sprintf( '%s (%s%%)', $base_label, $rule['rate'] );
+							} else {
+								// For flat rate or if percentage already in label, just use the base label.
+								$label = $base_label;
+							}
+
+							// Create a unique key for grouping that includes the base label and rate.
+							$group_key = $base_label . '|' . ( $rule['type'] ?? 'flat' ) . '|' . ( $rule['rate'] ?? '0' );
+
+							// Group fees by rule for consolidation.
+							if ( ! isset( $fees_by_label[ $group_key ] ) ) {
+								$fees_by_label[ $group_key ] = array(
+									'base_label' => $base_label,
+									'label'      => $label,
+									'amount'     => 0,
+									'count'      => 0,
+									'rate'       => $rule['rate'] ?? '',
+									'type'       => $rule['type'] ?? 'flat',
+									'taxable'    => $this->is_fee_taxable( $rule ),
+									'tax_class'  => $this->get_fee_tax_class( $rule ),
+								);
+							}
+
+							$fees_by_label[ $group_key ]['amount'] += $fee;
+							++$fees_by_label[ $group_key ]['count'];
+
+							// Log fee application.
+							$this->log_debug(
+								sprintf(
+									'      Applied: %s = $%.2f (base: $%.2f)',
+									$label,
+									$fee,
+									$customs_value
+								)
+							);
+						}
+
+						$made_progress = true;
+					} else {
+						$still_pending[] = $rule;
+					}
+				}
+
+				$pending = $still_pending;
+
+				if ( ! $made_progress ) {
+					// Unresolvable: cycle or external dependency.
+					// Compute remaining rules on their own base so the cart still works.
+					foreach ( $pending as $rule ) {
+						$rule_id = isset( $rule['rule_id'] ) && '' !== $rule['rule_id'] ? $rule['rule_id'] : 'rule_' . wp_rand( 1000, 9999 );
+
+						$customs_value = $this->apply_valuation_method( $line_total, $cart_item, $cart, $rule );
+						$fee           = $this->calculate_single_fee( $rule, $customs_value );
+
+						if ( false !== $fee && $fee > 0 ) {
+							$calculated[ $rule_id ] = $fee;
+
+							$base_label = $this->get_fee_label( $rule, $destination_country, $origin );
+							$has_percentage = preg_match( '/\(\d+(?:\.\d+)?%\)/', $base_label );
+							if ( ! $has_percentage && isset( $rule['type'] ) && 'percentage' === $rule['type'] && ! empty( $rule['rate'] ) ) {
+								$label = sprintf( '%s (%s%%)', $base_label, $rule['rate'] );
+							} else {
+								$label = $base_label;
+							}
+
+							$group_key = $base_label . '|' . ( $rule['type'] ?? 'flat' ) . '|' . ( $rule['rate'] ?? '0' );
+
+							if ( ! isset( $fees_by_label[ $group_key ] ) ) {
+								$fees_by_label[ $group_key ] = array(
+									'base_label' => $base_label,
+									'label'      => $label,
+									'amount'     => 0,
+									'count'      => 0,
+									'rate'       => $rule['rate'] ?? '',
+									'type'       => $rule['type'] ?? 'flat',
+									'taxable'    => $this->is_fee_taxable( $rule ),
+									'tax_class'  => $this->get_fee_tax_class( $rule ),
+								);
+							}
+
+							$fees_by_label[ $group_key ]['amount'] += $fee;
+							++$fees_by_label[ $group_key ]['count'];
+
+							$this->log_debug(
+								sprintf(
+									'      Applied (unresolved deps): %s = $%.2f (base: $%.2f)',
+									$label,
+									$fee,
+									$customs_value
+								)
+							);
+						}
+					}
+					break;
+				}
+			}
 
 		// Convert grouped fees to array and update labels with count.
 		$fees = array();
@@ -679,6 +827,49 @@ class CFWC_Calculator {
 	}
 
 	/**
+	 * Detect cycles in base_includes dependencies for a set of rules.
+	 *
+	 * Uses DFS to detect any circular references between rules.
+	 *
+	 * @since 1.2.0
+	 * @param array  $rules      Rules to check.
+	 * @param string $start_id   Rule ID to start checking from.
+	 * @param array  $visited    Already visited rule IDs.
+	 * @return bool True if a cycle is detected.
+	 */
+	private function has_cycle( $rules, $start_id, $visited = array() ) {
+		$rule_map = array();
+		foreach ( $rules as $rule ) {
+			$rid = isset( $rule['rule_id'] ) ? $rule['rule_id'] : '';
+			if ( ! empty( $rid ) ) {
+				$rule_map[ $rid ] = $rule;
+			}
+		}
+
+		if ( ! isset( $rule_map[ $start_id ] ) ) {
+			return false;
+		}
+
+		$rule = $rule_map[ $start_id ];
+		$deps = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] ) ? $rule['base_includes'] : array();
+
+		foreach ( $deps as $dep_id ) {
+			if ( $dep_id === $start_id ) {
+				return true;
+			}
+			if ( in_array( $dep_id, $visited, true ) ) {
+				return true;
+			}
+			$visited[] = $dep_id;
+			if ( $this->has_cycle( $rules, $dep_id, $visited ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Calculate a single fee.
 	 *
 	 * @since 1.0.0
@@ -982,16 +1173,26 @@ class CFWC_Calculator {
 	 * Apply customs valuation method to line total.
 	 *
 	 * Supports FOB (product value only) and CIF (Cost, Insurance, Freight)
-	 * valuation methods for customs calculations.
+	 * valuation methods for customs calculations. Per-rule override takes
+	 * precedence over the global setting when the rule declares a specific
+	 * valuation_method.
 	 *
 	 * @since 1.1.4
 	 * @param float   $line_total Product line total.
 	 * @param array   $cart_item  Cart item data.
 	 * @param WC_Cart $cart       Cart object.
+	 * @param array   $rule       Optional. Rule data for per-rule valuation.
 	 * @return float Adjusted customs value.
 	 */
-	private function apply_valuation_method( $line_total, $cart_item, $cart ) {
-		$method = get_option( 'cfwc_valuation_method', 'fob' );
+	private function apply_valuation_method( $line_total, $cart_item, $cart, $rule = null ) {
+		$global_method = get_option( 'cfwc_valuation_method', 'fob' );
+
+		// Use per-rule valuation if set and valid; otherwise inherit global.
+		if ( ! empty( $rule['valuation_method'] ) && in_array( $rule['valuation_method'], array( 'fob', 'cif', 'cif_insurance' ), true ) ) {
+			$method = $rule['valuation_method'];
+		} else {
+			$method = $global_method;
+		}
 
 		// FOB: Return unchanged (current/default behavior).
 		if ( 'fob' === $method ) {
@@ -1044,8 +1245,9 @@ class CFWC_Calculator {
 		 * @param float   $line_total    Original product line total.
 		 * @param array   $cart_item     Cart item data.
 		 * @param string  $method        Valuation method (fob, cif, cif_insurance).
+		 * @param array   $rule          The matching rule data.
 		 */
-		return apply_filters( 'cfwc_customs_value', $customs_value, $line_total, $cart_item, $method );
+		return apply_filters( 'cfwc_customs_value', $customs_value, $line_total, $cart_item, $method, $rule );
 	}
 
 	/**

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -306,6 +306,37 @@ class CFWC_Calculator {
 				}
 			}
 
+			// Detect cycles once across the entire matching rule set.
+			$cycle_labels   = array();
+			$cycle_rule_ids = array();
+			foreach ( $matching_rules as $cr ) {
+				$cr_id = isset( $cr['rule_id'] ) && '' !== $cr['rule_id'] ? $cr['rule_id'] : '';
+				if ( '' !== $cr_id && $this->has_cycle( $matching_rules, $cr_id ) ) {
+					$cycle_labels[]            = $cr['label'] ?? $cr_id;
+					$cycle_rule_ids[ $cr_id ] = true;
+				}
+			}
+			if ( ! empty( $cycle_labels ) ) {
+				$cycle_labels = array_values( array_unique( $cycle_labels ) );
+				$this->log_debug(
+					sprintf(
+						'    WARNING: Cycle detected in base_includes for rules: %s. Skipping dependency fees for affected rules.',
+						implode( ', ', $cycle_labels )
+					),
+					'warning'
+				);
+				if ( function_exists( 'wc_get_logger' ) ) {
+					wc_get_logger()->warning(
+						sprintf(
+							'Cycle detected in customs fee rule dependencies: %s',
+							implode( ', ', $cycle_labels )
+						),
+						array( 'source' => 'customs-fees' )
+					);
+				}
+				set_transient( 'cfwc_rules_dependency_error', $cycle_labels, DAY_IN_SECONDS );
+			}
+
 			// Round-based dependency resolution for matching rules.
 			$calculated = array(); // rule_id => fee amount.
 			$pending    = $matching_rules;
@@ -348,43 +379,15 @@ class CFWC_Calculator {
 						// Apply valuation method per-rule.
 						$customs_value = $this->apply_valuation_method( $line_total, $cart_item, $cart, $rule );
 
-						// Cycle detection: check once before processing deps.
-						$has_cycle = $this->has_cycle( $matching_rules, $rule_id );
-						if ( $has_cycle ) {
-							$this->log_debug(
-								sprintf(
-									'    WARNING: Cycle detected in base_includes for rule "%s". Skipping dependency fees.',
-									$rule['label'] ?? $rule_id
-								),
-								'warning'
-							);
-							if ( function_exists( 'wc_get_logger' ) ) {
-								wc_get_logger()->warning(
-									sprintf(
-										'Cycle detected in customs fee rule dependencies: %s',
-										$rule['label'] ?? $rule_id
-									),
-									array( 'source' => 'customs-fees' )
-								);
-							}
-							// Set admin notice transient once per calculation.
-							$cycle_labels = array();
-							foreach ( $matching_rules as $r ) {
-								if ( $this->has_cycle( $matching_rules, $r['rule_id'] ?? '' ) ) {
-									$cycle_labels[] = $r['label'] ?? ( $r['rule_id'] ?? '' );
-								}
-							}
-							if ( ! empty( $cycle_labels ) ) {
-								set_transient( 'cfwc_rules_dependency_error', array_unique( $cycle_labels ), DAY_IN_SECONDS );
-							}
-						} else {
-							// Add included fees from dependencies.
+						// Add included fees from dependencies, unless this rule participates in a cycle.
+						if ( ! isset( $cycle_rule_ids[ $rule_id ] ) ) {
 							foreach ( $deps as $dep_id ) {
-								// Self-reference protection.
 								if ( $dep_id === $rule_id ) {
 									continue;
 								}
-								$customs_value += $calculated[ $dep_id ];
+								if ( isset( $calculated[ $dep_id ] ) ) {
+									$customs_value += $calculated[ $dep_id ];
+								}
 							}
 						}
 
@@ -861,8 +864,9 @@ class CFWC_Calculator {
 			if ( in_array( $dep_id, $visited, true ) ) {
 				return true;
 			}
-			$visited[] = $dep_id;
-			if ( $this->has_cycle( $rules, $dep_id, $visited ) ) {
+			$path   = $visited;
+			$path[] = $dep_id;
+			if ( $this->has_cycle( $rules, $dep_id, $path ) ) {
 				return true;
 			}
 		}

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -348,43 +348,44 @@ class CFWC_Calculator {
 						// Apply valuation method per-rule.
 						$customs_value = $this->apply_valuation_method( $line_total, $cart_item, $cart, $rule );
 
-						// Add included fees from dependencies.
-						foreach ( $deps as $dep_id ) {
-							// Self-reference protection.
-							if ( $dep_id === $rule_id ) {
-								continue;
-							}
-							// Cycle detection.
-							if ( $this->has_cycle( $matching_rules, $rule_id ) ) {
-								$this->log_debug(
+						// Cycle detection: check once before processing deps.
+						$has_cycle = $this->has_cycle( $matching_rules, $rule_id );
+						if ( $has_cycle ) {
+							$this->log_debug(
+								sprintf(
+									'    WARNING: Cycle detected in base_includes for rule "%s". Skipping dependency fees.',
+									$rule['label'] ?? $rule_id
+								),
+								'warning'
+							);
+							if ( function_exists( 'wc_get_logger' ) ) {
+								wc_get_logger()->warning(
 									sprintf(
-										'    WARNING: Cycle detected in base_includes for rule "%s". Skipping dependency fees.',
+										'Cycle detected in customs fee rule dependencies: %s',
 										$rule['label'] ?? $rule_id
 									),
-									'warning'
+									array( 'source' => 'customs-fees' )
 								);
-								if ( function_exists( 'wc_get_logger' ) ) {
-									wc_get_logger()->warning(
-										sprintf(
-											'Cycle detected in customs fee rule dependencies: %s',
-											$rule['label'] ?? $rule_id
-										),
-										array( 'source' => 'customs-fees' )
-									);
-								}
-								// Set admin notice transient.
-								$cycle_labels = array();
-								foreach ( $matching_rules as $r ) {
-									if ( $this->has_cycle( $matching_rules, $r['rule_id'] ?? '' ) ) {
-										$cycle_labels[] = $r['label'] ?? ( $r['rule_id'] ?? '' );
-									}
-								}
-								if ( ! empty( $cycle_labels ) ) {
-									set_transient( 'cfwc_rules_dependency_error', array_unique( $cycle_labels ), DAY_IN_SECONDS );
-								}
-								break;
 							}
-							$customs_value += $calculated[ $dep_id ];
+							// Set admin notice transient once per calculation.
+							$cycle_labels = array();
+							foreach ( $matching_rules as $r ) {
+								if ( $this->has_cycle( $matching_rules, $r['rule_id'] ?? '' ) ) {
+									$cycle_labels[] = $r['label'] ?? ( $r['rule_id'] ?? '' );
+								}
+							}
+							if ( ! empty( $cycle_labels ) ) {
+								set_transient( 'cfwc_rules_dependency_error', array_unique( $cycle_labels ), DAY_IN_SECONDS );
+							}
+						} else {
+							// Add included fees from dependencies.
+							foreach ( $deps as $dep_id ) {
+								// Self-reference protection.
+								if ( $dep_id === $rule_id ) {
+									continue;
+								}
+								$customs_value += $calculated[ $dep_id ];
+							}
 						}
 
 						$fee = $this->calculate_single_fee( $rule, $customs_value );

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -395,41 +395,8 @@ class CFWC_Calculator {
 
 						if ( false !== $fee && $fee > 0 ) {
 							$calculated[ $rule_id ] = $fee;
+							$label                   = $this->accumulate_fee( $fees_by_label, $rule, $fee, $destination_country, $origin );
 
-							$base_label = $this->get_fee_label( $rule, $destination_country, $origin );
-
-							// Check if the label already contains a percentage (e.g., "(50%)").
-							$has_percentage = preg_match( '/\(\d+(?:\.\d+)?%\)/', $base_label );
-
-							// Add percentage rate in brackets only if not already present and it's a percentage rule.
-							if ( ! $has_percentage && isset( $rule['type'] ) && 'percentage' === $rule['type'] && ! empty( $rule['rate'] ) ) {
-								$label = sprintf( '%s (%s%%)', $base_label, $rule['rate'] );
-							} else {
-								// For flat rate or if percentage already in label, just use the base label.
-								$label = $base_label;
-							}
-
-							// Create a unique key for grouping that includes the base label and rate.
-							$group_key = $base_label . '|' . ( $rule['type'] ?? 'flat' ) . '|' . ( $rule['rate'] ?? '0' );
-
-							// Group fees by rule for consolidation.
-							if ( ! isset( $fees_by_label[ $group_key ] ) ) {
-								$fees_by_label[ $group_key ] = array(
-									'base_label' => $base_label,
-									'label'      => $label,
-									'amount'     => 0,
-									'count'      => 0,
-									'rate'       => $rule['rate'] ?? '',
-									'type'       => $rule['type'] ?? 'flat',
-									'taxable'    => $this->is_fee_taxable( $rule ),
-									'tax_class'  => $this->get_fee_tax_class( $rule ),
-								);
-							}
-
-							$fees_by_label[ $group_key ]['amount'] += $fee;
-							++$fees_by_label[ $group_key ]['count'];
-
-							// Log fee application.
 							$this->log_debug(
 								sprintf(
 									'      Applied: %s = $%.2f (base: $%.2f)',
@@ -459,32 +426,7 @@ class CFWC_Calculator {
 
 						if ( false !== $fee && $fee > 0 ) {
 							$calculated[ $rule_id ] = $fee;
-
-							$base_label = $this->get_fee_label( $rule, $destination_country, $origin );
-							$has_percentage = preg_match( '/\(\d+(?:\.\d+)?%\)/', $base_label );
-							if ( ! $has_percentage && isset( $rule['type'] ) && 'percentage' === $rule['type'] && ! empty( $rule['rate'] ) ) {
-								$label = sprintf( '%s (%s%%)', $base_label, $rule['rate'] );
-							} else {
-								$label = $base_label;
-							}
-
-							$group_key = $base_label . '|' . ( $rule['type'] ?? 'flat' ) . '|' . ( $rule['rate'] ?? '0' );
-
-							if ( ! isset( $fees_by_label[ $group_key ] ) ) {
-								$fees_by_label[ $group_key ] = array(
-									'base_label' => $base_label,
-									'label'      => $label,
-									'amount'     => 0,
-									'count'      => 0,
-									'rate'       => $rule['rate'] ?? '',
-									'type'       => $rule['type'] ?? 'flat',
-									'taxable'    => $this->is_fee_taxable( $rule ),
-									'tax_class'  => $this->get_fee_tax_class( $rule ),
-								);
-							}
-
-							$fees_by_label[ $group_key ]['amount'] += $fee;
-							++$fees_by_label[ $group_key ]['count'];
+							$label                   = $this->accumulate_fee( $fees_by_label, $rule, $fee, $destination_country, $origin );
 
 							$this->log_debug(
 								sprintf(
@@ -829,6 +771,51 @@ class CFWC_Calculator {
 		$this->rules_cache = $rules;
 
 		return apply_filters( 'cfwc_all_rules', $rules );
+	}
+
+	/**
+	 * Accumulate a calculated fee into the by-label grouping structure.
+	 *
+	 * Handles label generation (with optional percentage annotation),
+	 * grouping key creation, and per-group consolidation.
+	 *
+	 * @since 1.2.0
+	 * @param array  &$fees_by_label    Reference to the fees grouping array.
+	 * @param array  $rule              Rule data.
+	 * @param float  $fee               Calculated fee amount.
+	 * @param string $destination_country Destination country code.
+	 * @param string $origin            Origin country code.
+	 * @return string The generated display label.
+	 */
+	private function accumulate_fee( &$fees_by_label, $rule, $fee, $destination_country, $origin ) {
+		$base_label     = $this->get_fee_label( $rule, $destination_country, $origin );
+		$has_percentage = preg_match( '/\(\d+(?:\.\d+)?%\)/', $base_label );
+
+		if ( ! $has_percentage && isset( $rule['type'] ) && 'percentage' === $rule['type'] && ! empty( $rule['rate'] ) ) {
+			$label = sprintf( '%s (%s%%)', $base_label, $rule['rate'] );
+		} else {
+			$label = $base_label;
+		}
+
+		$group_key = $base_label . '|' . ( $rule['type'] ?? 'flat' ) . '|' . ( $rule['rate'] ?? '0' );
+
+		if ( ! isset( $fees_by_label[ $group_key ] ) ) {
+			$fees_by_label[ $group_key ] = array(
+				'base_label' => $base_label,
+				'label'      => $label,
+				'amount'     => 0,
+				'count'      => 0,
+				'rate'       => $rule['rate'] ?? '',
+				'type'       => $rule['type'] ?? 'flat',
+				'taxable'    => $this->is_fee_taxable( $rule ),
+				'tax_class'  => $this->get_fee_tax_class( $rule ),
+			);
+		}
+
+		$fees_by_label[ $group_key ]['amount'] += $fee;
+		++$fees_by_label[ $group_key ]['count'];
+
+		return $label;
 	}
 
 	/**

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -351,7 +351,7 @@ class CFWC_Calculator {
 				foreach ( $pending as $rule ) {
 					$rule_id = isset( $rule['rule_id'] ) && '' !== $rule['rule_id'] ? $rule['rule_id'] : (string) array_search( $rule, $matching_rules, true );
 					if ( '' === $rule_id ) {
-						$rule_id = 'rule_' . wp_rand( 1000, 9999 );
+						$rule_id = 'rule_' . wp_generate_uuid4();
 					}
 
 					$deps = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] )
@@ -419,7 +419,7 @@ class CFWC_Calculator {
 					// Unresolvable: cycle or external dependency.
 					// Compute remaining rules on their own base so the cart still works.
 					foreach ( $pending as $rule ) {
-						$rule_id = isset( $rule['rule_id'] ) && '' !== $rule['rule_id'] ? $rule['rule_id'] : 'rule_' . wp_rand( 1000, 9999 );
+						$rule_id = isset( $rule['rule_id'] ) && '' !== $rule['rule_id'] ? $rule['rule_id'] : 'rule_' . wp_generate_uuid4();
 
 						$customs_value = $this->apply_valuation_method( $line_total, $cart_item, $cart, $rule );
 						$fee           = $this->calculate_single_fee( $rule, $customs_value );

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -211,6 +211,10 @@ class CFWC_Calculator {
 				$rules
 			);
 
+			// Capture any rules the matcher removed via override/exclusive
+			// stacking, so we can warn below if a surviving rule depended on one.
+			$stacking_dropped = $rule_matcher->get_last_stacking_dropped();
+
 			// Calculate fees for this product.
 			// Check if we should use original price (before discounts).
 			$use_original_price = get_option( 'cfwc_use_original_price', 'no' );
@@ -328,6 +332,34 @@ class CFWC_Calculator {
 				// Notice state is maintained by refresh_cycle_notice() on every
 				// rule-mutation path (settings save, ajax save/reorder/import),
 				// so the cart calculator does not need to write wp_options here.
+			}
+
+			// Warn when a surviving rule declares a base_includes dependency on a
+			// rule that was just removed by a higher-priority override/exclusive
+			// rule for this destination. The dependency is silently filtered out
+			// during resolution below, so the dependent fee computes on an
+			// un-compounded base (e.g. GST no longer compounds on duty). This is
+			// a compliance-relevant under-statement with no other signal, so log
+			// it; checkout still completes on the own-base fallback.
+			if ( ! empty( $stacking_dropped ) ) {
+				$dropped_lookup = array_flip( $stacking_dropped );
+				foreach ( $matching_rules as $mr ) {
+					$mr_deps = isset( $mr['base_includes'] ) && is_array( $mr['base_includes'] )
+						? $mr['base_includes']
+						: array();
+					foreach ( $mr_deps as $dep_id ) {
+						if ( isset( $dropped_lookup[ $dep_id ] ) ) {
+							$this->log_debug(
+								sprintf(
+									'    WARNING: Rule "%s" depends on rule_id "%s", which was removed by a higher-priority override/exclusive rule for this destination. The dependent fee will be calculated on an un-compounded base. Review the stacking modes if this rule should compound on it.',
+									isset( $mr['label'] ) && '' !== $mr['label'] ? $mr['label'] : ( $mr['rule_id'] ?? '' ),
+									$dep_id
+								),
+								'warning'
+							);
+						}
+					}
+				}
 			}
 
 			// Round-based dependency resolution for matching rules.
@@ -926,6 +958,11 @@ class CFWC_Calculator {
 	 * Called from every rule-mutation site so the admin notice reflects the
 	 * current saved state instead of waiting for the next calculator run to
 	 * re-derive it. Sets the transient when cycles exist, deletes it otherwise.
+	 *
+	 * The stacking-broken-dependency notice does NOT use this transient: it is
+	 * computed on demand on the Customs Fees settings screen (see
+	 * CFWC_Admin::maybe_show_broken_dependency_notice()), so there is no cache
+	 * to keep in sync here.
 	 *
 	 * @since 1.2.0
 	 * @param array $rules Rule set just persisted to the `cfwc_rules` option.

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -325,7 +325,9 @@ class CFWC_Calculator {
 					),
 					'warning'
 				);
-				set_transient( 'cfwc_rules_dependency_error', $cycle_labels, DAY_IN_SECONDS );
+				// Notice state is maintained by refresh_cycle_notice() on every
+				// rule-mutation path (settings save, ajax save/reorder/import),
+				// so the cart calculator does not need to write wp_options here.
 			}
 
 			// Round-based dependency resolution for matching rules.

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -865,12 +865,13 @@ class CFWC_Calculator {
 
 		$rule  = $rule_map[ $start_id ];
 		$queue = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] )
-			? $rule['base_includes']
+			? array_values( $rule['base_includes'] )
 			: array();
 		$seen  = array();
+		$head  = 0;
 
-		while ( ! empty( $queue ) ) {
-			$current = array_shift( $queue );
+		while ( $head < count( $queue ) ) {
+			$current = $queue[ $head++ ];
 
 			if ( $current === $start_id ) {
 				return true;

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -1289,6 +1289,8 @@ class CFWC_Calculator {
 		 * Filter the calculated customs value.
 		 *
 		 * @since 1.1.4
+		 * @since 1.2.0 Added the $rule parameter.
+		 *
 		 * @param float   $customs_value The calculated customs value.
 		 * @param float   $line_total    Original product line total.
 		 * @param array   $cart_item     Cart item data.

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -878,6 +878,48 @@ class CFWC_Calculator {
 	}
 
 	/**
+	 * Returns the labels of every rule that participates in a dependency cycle.
+	 *
+	 * Mirrors the per-rule scan the calculator performs, but operates on an
+	 * arbitrary rule set (typically the freshly-saved `cfwc_rules` option) so
+	 * admin code can derive the warning state without waiting for a cart
+	 * calculation. Empty array means the rule set is acyclic.
+	 *
+	 * @since 1.2.0
+	 * @param array $rules Rule set to inspect.
+	 * @return array<int,string> Unique, re-indexed list of cyclic rule labels.
+	 */
+	public static function detect_cycle_labels( $rules ) {
+		$labels = array();
+		foreach ( (array) $rules as $rule ) {
+			$rid = isset( $rule['rule_id'] ) ? $rule['rule_id'] : '';
+			if ( '' !== $rid && self::has_cycle( $rules, $rid ) ) {
+				$labels[] = ( isset( $rule['label'] ) && '' !== $rule['label'] ) ? $rule['label'] : $rid;
+			}
+		}
+		return array_values( array_unique( $labels ) );
+	}
+
+	/**
+	 * Sync the dependency-error transient to the supplied rule set.
+	 *
+	 * Called from every rule-mutation site so the admin notice reflects the
+	 * current saved state instead of waiting for the next calculator run to
+	 * re-derive it. Sets the transient when cycles exist, deletes it otherwise.
+	 *
+	 * @since 1.2.0
+	 * @param array $rules Rule set just persisted to the `cfwc_rules` option.
+	 */
+	public static function refresh_cycle_notice( $rules ) {
+		$labels = self::detect_cycle_labels( $rules );
+		if ( ! empty( $labels ) ) {
+			set_transient( 'cfwc_rules_dependency_error', $labels, DAY_IN_SECONDS );
+		} else {
+			delete_transient( 'cfwc_rules_dependency_error' );
+		}
+	}
+
+	/**
 	 * Calculate a single fee.
 	 *
 	 * @since 1.0.0

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -349,9 +349,42 @@ class CFWC_Calculator {
 				$still_pending = array();
 
 				foreach ( $pending as $rule ) {
-					$rule_id = isset( $rule['rule_id'] ) && '' !== $rule['rule_id'] ? $rule['rule_id'] : (string) array_search( $rule, $matching_rules, true );
-					if ( '' === $rule_id ) {
-						$rule_id = 'rule_' . wp_generate_uuid4();
+					if ( isset( $rule['rule_id'] ) && '' !== $rule['rule_id'] ) {
+						$rule_id = $rule['rule_id'];
+					} else {
+						$found_index = array_search( $rule, $matching_rules, true );
+						$rule_id     = false !== $found_index ? (string) $found_index : '';
+
+						// If the fallback id is already in $calculated, two rules
+						// without a rule_id resolved to the same array_search index
+						// — i.e. the merchant has duplicate identical rules. Surface
+						// this so it can be cleaned up; otherwise the second one
+						// silently overwrites the first in $calculated.
+						if ( '' !== $rule_id && isset( $calculated[ $rule_id ] ) ) {
+							$dup_label = isset( $rule['label'] ) && '' !== $rule['label']
+								? $rule['label']
+								: ( isset( $rule['country'] ) ? $rule['country'] : '' );
+							$this->log_debug(
+								sprintf(
+									'    WARNING: Duplicate rule detected (no rule_id, label "%s"). Only the first match will apply — assign a unique rule_id or remove the duplicate.',
+									$dup_label
+								),
+								'warning'
+							);
+							if ( function_exists( 'wc_get_logger' ) ) {
+								wc_get_logger()->warning(
+									sprintf(
+										'Customs fee rule "%s" is missing a rule_id and is identical to another rule. Duplicate rules detected — assign a unique rule_id or remove the duplicate.',
+										$dup_label
+									),
+									array( 'source' => 'customs-fees' )
+								);
+							}
+						}
+
+						if ( '' === $rule_id ) {
+							$rule_id = 'rule_' . wp_generate_uuid4();
+						}
 					}
 
 					$deps = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] )

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -325,15 +325,6 @@ class CFWC_Calculator {
 					),
 					'warning'
 				);
-				if ( function_exists( 'wc_get_logger' ) ) {
-					wc_get_logger()->warning(
-						sprintf(
-							'Cycle detected in customs fee rule dependencies: %s',
-							implode( ', ', $cycle_labels )
-						),
-						array( 'source' => 'customs-fees' )
-					);
-				}
 				set_transient( 'cfwc_rules_dependency_error', $cycle_labels, DAY_IN_SECONDS );
 			}
 
@@ -371,15 +362,6 @@ class CFWC_Calculator {
 								),
 								'warning'
 							);
-							if ( function_exists( 'wc_get_logger' ) ) {
-								wc_get_logger()->warning(
-									sprintf(
-										'Customs fee rule "%s" is missing a rule_id and is identical to another rule. Duplicate rules detected — assign a unique rule_id or remove the duplicate.',
-										$dup_label
-									),
-									array( 'source' => 'customs-fees' )
-								);
-							}
 						}
 
 						if ( '' === $rule_id ) {

--- a/includes/class-cfwc-calculator.php
+++ b/includes/class-cfwc-calculator.php
@@ -836,17 +836,21 @@ class CFWC_Calculator {
 	}
 
 	/**
-	 * Detect cycles in base_includes dependencies for a set of rules.
+	 * Detect whether a rule participates in a `base_includes` cycle.
 	 *
-	 * Uses DFS to detect any circular references between rules.
+	 * Walks the dependency graph breadth-first from `$start_id` and returns
+	 * true only if a path leads back to `$start_id` itself — i.e. `$start_id`
+	 * is part of a cycle. Rules that are merely upstream of a cycle (they
+	 * reach a cycle but do not loop back to themselves) correctly return
+	 * false; the calculator's round-loop already handles their unresolvable
+	 * dependencies via the own-base fallback.
 	 *
 	 * @since 1.2.0
-	 * @param array  $rules      Rules to check.
-	 * @param string $start_id   Rule ID to start checking from.
-	 * @param array  $visited    Already visited rule IDs.
-	 * @return bool True if a cycle is detected.
+	 * @param array  $rules    Rules to check.
+	 * @param string $start_id Rule ID to test for cycle membership.
+	 * @return bool True if `$start_id` participates in a cycle.
 	 */
-	public static function has_cycle( $rules, $start_id, $visited = array() ) {
+	public static function has_cycle( $rules, $start_id ) {
 		$rule_map = array();
 		foreach ( $rules as $rule ) {
 			$rid = isset( $rule['rule_id'] ) ? $rule['rule_id'] : '';
@@ -859,20 +863,33 @@ class CFWC_Calculator {
 			return false;
 		}
 
-		$rule = $rule_map[ $start_id ];
-		$deps = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] ) ? $rule['base_includes'] : array();
+		$rule  = $rule_map[ $start_id ];
+		$queue = isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] )
+			? $rule['base_includes']
+			: array();
+		$seen  = array();
 
-		foreach ( $deps as $dep_id ) {
-			if ( $dep_id === $start_id ) {
+		while ( ! empty( $queue ) ) {
+			$current = array_shift( $queue );
+
+			if ( $current === $start_id ) {
 				return true;
 			}
-			if ( in_array( $dep_id, $visited, true ) ) {
-				return true;
+			if ( isset( $seen[ $current ] ) ) {
+				continue;
 			}
-			$path   = $visited;
-			$path[] = $dep_id;
-			if ( self::has_cycle( $rules, $dep_id, $path ) ) {
-				return true;
+			$seen[ $current ] = true;
+
+			if ( ! isset( $rule_map[ $current ] ) ) {
+				continue;
+			}
+
+			$cur_rule = $rule_map[ $current ];
+			$cur_deps = isset( $cur_rule['base_includes'] ) && is_array( $cur_rule['base_includes'] )
+				? $cur_rule['base_includes']
+				: array();
+			foreach ( $cur_deps as $dep ) {
+				$queue[] = $dep;
 			}
 		}
 

--- a/includes/class-cfwc-display.php
+++ b/includes/class-cfwc-display.php
@@ -188,9 +188,9 @@ class CFWC_Display {
 						$value_html .= '</table>';
 					} else {
 						// Regular display for web pages.
-						$value_html = '<div class="cfwc-fees-breakdown-wrapper" style="display: block;">';
+						$value_html = '<div class="cfwc-fees-breakdown-wrapper">';
 						foreach ( $breakdown as $fee_item ) {
-							$value_html .= '<div class="cfwc-fee-item" style="display: block; margin: 0 0 5px 0; padding: 0;">';
+							$value_html .= '<div class="cfwc-fee-item">';
 							$value_html .= '<span class="cfwc-fee-label">' . esc_html( $fee_item['label'] ) . ':</span> ';
 							$value_html .= '<strong>' . wc_price( $fee_item['amount'], array( 'currency' => $order->get_currency() ) ) . '</strong>';
 							$value_html .= '</div>';
@@ -350,6 +350,7 @@ class CFWC_Display {
 
 		if ( ! empty( $extra_info ) ) {
 			// Add to product name.
+			// Inline style: email clients strip <style> blocks and ignore external CSS.
 			$args['product'] .= '<br><small style="color: #666; font-size: 0.9em;">' . implode( ' | ', $extra_info ) . '</small>';
 		}
 

--- a/includes/class-cfwc-rule-matcher.php
+++ b/includes/class-cfwc-rule-matcher.php
@@ -52,9 +52,11 @@ class CFWC_Rule_Matcher {
 	public function find_matching_rules( $product, $from_country, $to_country, $all_rules ) {
 		$matching_rules = array();
 
-		foreach ( $all_rules as $rule_id => $rule ) {
+		foreach ( $all_rules as $key => $rule ) {
 			if ( $this->does_rule_match( $rule, $product, $from_country, $to_country ) ) {
-				$rule['rule_id']  = $rule_id;
+				if ( empty( $rule['rule_id'] ) ) {
+					$rule['rule_id'] = (string) $key;
+				}
 				$matching_rules[] = $rule;
 			}
 		}

--- a/includes/class-cfwc-rule-matcher.php
+++ b/includes/class-cfwc-rule-matcher.php
@@ -40,6 +40,18 @@ class CFWC_Rule_Matcher {
 	const STACK_EXCLUSIVE = 'exclusive'; // Only this rule applies.
 
 	/**
+	 * Rule IDs that matched the cart item but were removed by stacking modes
+	 * (override/exclusive) during the most recent find_matching_rules() call.
+	 *
+	 * Lets the calculator tell a deliberately dropped base_includes dependency
+	 * apart from one that simply never matched, so it can warn about the former.
+	 *
+	 * @since 1.2.0
+	 * @var array<int,string>
+	 */
+	private $last_stacking_dropped = array();
+
+	/**
 	 * Find matching rules for a product.
 	 *
 	 * @since 1.1.4
@@ -83,7 +95,54 @@ class CFWC_Rule_Matcher {
 		}
 
 		// Handle stacking modes.
-		return $this->apply_stacking_modes( $matching_rules );
+		$final_rules = $this->apply_stacking_modes( $matching_rules );
+
+		// Record which matched rules were removed by stacking so the calculator
+		// can warn when a surviving rule depends (via base_includes) on one of
+		// them — otherwise that dependency is silently dropped and the dependent
+		// fee is computed on an un-compounded base.
+		$this->record_stacking_dropped( $matching_rules, $final_rules );
+
+		return $final_rules;
+	}
+
+	/**
+	 * Record the rule IDs that matched but were dropped by stacking modes.
+	 *
+	 * Stores the set difference between the matched rules (pre-stacking) and the
+	 * surviving rules (post-stacking) in $last_stacking_dropped.
+	 *
+	 * @since 1.2.0
+	 * @param array $matched   Rules that matched before stacking was applied.
+	 * @param array $survivors Rules that remain after stacking was applied.
+	 */
+	private function record_stacking_dropped( $matched, $survivors ) {
+		$surviving_ids = array();
+		foreach ( $survivors as $rule ) {
+			if ( ! empty( $rule['rule_id'] ) ) {
+				$surviving_ids[ $rule['rule_id'] ] = true;
+			}
+		}
+
+		$dropped = array();
+		foreach ( $matched as $rule ) {
+			$rid = isset( $rule['rule_id'] ) ? $rule['rule_id'] : '';
+			if ( '' !== $rid && ! isset( $surviving_ids[ $rid ] ) ) {
+				$dropped[ $rid ] = true;
+			}
+		}
+
+		$this->last_stacking_dropped = array_keys( $dropped );
+	}
+
+	/**
+	 * Get the rule IDs dropped by stacking during the last find_matching_rules() call.
+	 *
+	 * @since 1.2.0
+	 * @return array<int,string> Dropped rule IDs (empty when nothing was stacking-filtered).
+	 */
+	public function get_last_stacking_dropped() {
+		return $this->last_stacking_dropped;
 	}
 
 	/**
@@ -437,6 +496,176 @@ class CFWC_Rule_Matcher {
 		}
 
 		return $final_rules;
+	}
+
+	/**
+	 * Detect base_includes dependencies that are broken by stacking modes.
+	 *
+	 * Case (a) of the stacking/compounding interaction: a rule still applies
+	 * after stacking, but a rule it depends on (via base_includes) was removed
+	 * by a higher-priority override/exclusive rule for the same destination — so
+	 * the surviving rule's fee is computed on an incomplete (un-compounded) base.
+	 *
+	 * This runs at save time, so it only inspects rules that PROVABLY co-occur
+	 * for some concrete product: general rules (match_type 'all'), grouped by
+	 * destination and then by overlapping origin scope. Within a destination,
+	 * an origin-restricted rule co-occurs with any-origin rules (and same-origin
+	 * rules) for products of that origin, so each origin is analysed as
+	 * "any-origin rules + that origin's rules" — exactly the set such a product
+	 * matches. Rules restricted to *different* origins never co-occur and are
+	 * never analysed together, so there are no false positives. Category/HS-code
+	 * rules match per-product and are left to the calculator's runtime warning.
+	 *
+	 * The inverse case — where the dependent rule is itself dropped, so the fee
+	 * disappears entirely — is intentionally NOT reported here: replacing rules
+	 * is the documented purpose of override/exclusive stacking, so flagging it
+	 * would nag on deliberate configurations.
+	 *
+	 * @since 1.2.0
+	 * @param array $rules Rule set to inspect (typically the saved cfwc_rules).
+	 * @return array<int,string> Labels of surviving rules with a stacking-dropped dependency.
+	 */
+	public static function detect_broken_dependencies( $rules ) {
+		if ( ! is_array( $rules ) || empty( $rules ) ) {
+			return array();
+		}
+
+		$matcher        = new self();
+		$by_destination = array();
+
+		foreach ( $rules as $key => $rule ) {
+			// Only general rules can be statically proven to co-occur.
+			$match_type = $rule['match_type'] ?? self::MATCH_ALL;
+			if ( self::MATCH_ALL !== $match_type ) {
+				continue;
+			}
+
+			$dest = $rule['to_country'] ?? $rule['country'] ?? '';
+			if ( '' === $dest ) {
+				continue;
+			}
+
+			if ( empty( $rule['rule_id'] ) ) {
+				$rule['rule_id'] = (string) $key;
+			}
+
+			$by_destination[ $dest ][] = $rule;
+		}
+
+		$broken = array();
+
+		foreach ( $by_destination as $group ) {
+			// Split by origin scope: any-origin rules co-occur with everything;
+			// origin-restricted rules co-occur only within their own origin.
+			$any_origin = array();
+			$by_origin  = array();
+			foreach ( $group as $rule ) {
+				$from = $rule['from_country'] ?? $rule['origin_country'] ?? '';
+				if ( '' === $from ) {
+					$any_origin[] = $rule;
+				} else {
+					$by_origin[ $from ][] = $rule;
+				}
+			}
+
+			// One analysis set per concrete origin (plus the any-origin baseline
+			// when no origin-restricted rules exist for this destination).
+			$sets = array();
+			if ( empty( $by_origin ) ) {
+				$sets[] = $any_origin;
+			} else {
+				foreach ( $by_origin as $origin_rules ) {
+					$sets[] = array_merge( $any_origin, $origin_rules );
+				}
+			}
+
+			foreach ( $sets as $set ) {
+				foreach ( $matcher->find_broken_dependencies_in_set( $set ) as $label ) {
+					$broken[] = $label;
+				}
+			}
+		}
+
+		return array_values( array_unique( $broken ) );
+	}
+
+	/**
+	 * Find surviving rules whose dependency is dropped by stacking, in one set.
+	 *
+	 * The caller passes a set of rules that all provably co-occur for some
+	 * product (same destination, overlapping origin). This reproduces the
+	 * runtime ordering + stacking and returns the labels of any surviving rule
+	 * whose base_includes references a rule that stacking removed (case (a)).
+	 *
+	 * @since 1.2.0
+	 * @param array $set Co-occurring rules to analyse.
+	 * @return array<int,string> Labels of surviving rules with a dropped dependency.
+	 */
+	private function find_broken_dependencies_in_set( $set ) {
+		if ( count( $set ) < 2 ) {
+			return array();
+		}
+
+		usort( $set, array( $this, 'sort_by_priority' ) );
+		$survivors = $this->apply_stacking_modes( $set );
+
+		$survivor_ids = array();
+		foreach ( $survivors as $survivor ) {
+			if ( ! empty( $survivor['rule_id'] ) ) {
+				$survivor_ids[ $survivor['rule_id'] ] = true;
+			}
+		}
+
+		// Dropped = matched in this set but not surviving.
+		$dropped = array();
+		foreach ( $set as $candidate ) {
+			$candidate_id = $candidate['rule_id'] ?? '';
+			if ( '' !== $candidate_id && ! isset( $survivor_ids[ $candidate_id ] ) ) {
+				$dropped[ $candidate_id ] = true;
+			}
+		}
+
+		if ( empty( $dropped ) ) {
+			return array();
+		}
+
+		$found = array();
+		foreach ( $survivors as $survivor ) {
+			$deps = isset( $survivor['base_includes'] ) && is_array( $survivor['base_includes'] )
+				? $survivor['base_includes']
+				: array();
+
+			foreach ( $deps as $dep_id ) {
+				if ( isset( $dropped[ $dep_id ] ) ) {
+					$found[] = ( isset( $survivor['label'] ) && '' !== $survivor['label'] )
+						? $survivor['label']
+						: $survivor['rule_id'];
+					break;
+				}
+			}
+		}
+
+		return $found;
+	}
+
+	/**
+	 * Derive a stable signature for a set of broken-dependency labels.
+	 *
+	 * Used to key a merchant's dismissal of the broken-dependency notice to the
+	 * specific conflict they saw: if the set of affected rules later changes,
+	 * the signature changes and the notice re-surfaces. Order-independent.
+	 *
+	 * @since 1.2.0
+	 * @param array $labels Labels returned by detect_broken_dependencies().
+	 * @return string Signature hash (empty string for an empty set).
+	 */
+	public static function broken_dependency_signature( $labels ) {
+		$labels = array_map( 'strval', (array) $labels );
+		if ( empty( $labels ) ) {
+			return '';
+		}
+		sort( $labels );
+		return md5( implode( '|', $labels ) );
 	}
 
 	/**

--- a/includes/class-cfwc-settings.php
+++ b/includes/class-cfwc-settings.php
@@ -284,6 +284,18 @@ class CFWC_Settings {
 			WC()->session->set( 'cfwc_tooltip_text', null );
 		}
 
+		// Explicitly delete the rules transient. wp_cache_flush() does not
+		// remove DB-backed transients without a persistent object cache, so
+		// the rules cache could otherwise survive a settings save and the
+		// calculator would keep returning stale rule data.
+		delete_transient( 'cfwc_rules_cache' );
+
+		// Clear in-memory calculator cache for this request.
+		if ( class_exists( 'CFWC_Calculator' ) ) {
+			$calculator = new CFWC_Calculator();
+			$calculator->clear_cache();
+		}
+
 		// Clear all caches.
 		wp_cache_flush();
 

--- a/includes/class-cfwc-settings.php
+++ b/includes/class-cfwc-settings.php
@@ -114,10 +114,7 @@ class CFWC_Settings {
 
 			// Clear calculator cache if class exists.
 			if ( class_exists( 'CFWC_Calculator' ) ) {
-				$calculator = new CFWC_Calculator();
-				if ( method_exists( $calculator, 'clear_cache' ) ) {
-					$calculator->clear_cache();
-				}
+				CFWC_Calculator::clear_cache();
 			}
 		} catch ( Exception $e ) {
 			// Log error only when debugging is enabled.
@@ -292,8 +289,7 @@ class CFWC_Settings {
 
 		// Clear in-memory calculator cache for this request.
 		if ( class_exists( 'CFWC_Calculator' ) ) {
-			$calculator = new CFWC_Calculator();
-			$calculator->clear_cache();
+			CFWC_Calculator::clear_cache();
 		}
 
 		// Clear all caches.

--- a/includes/class-cfwc-settings.php
+++ b/includes/class-cfwc-settings.php
@@ -251,7 +251,17 @@ class CFWC_Settings {
 						'category_ids'    => isset( $rule['category_ids'] ) ? array_map( 'absint', (array) $rule['category_ids'] ) : array(),
 						'hs_code_pattern' => isset( $rule['hs_code_pattern'] ) ? sanitize_text_field( $rule['hs_code_pattern'] ) : '',
 						'priority'        => isset( $rule['priority'] ) ? absint( $rule['priority'] ) : 0,
-						'stacking_mode'   => isset( $rule['stacking_mode'] ) ? sanitize_text_field( $rule['stacking_mode'] ) : 'add',
+						'stacking_mode'    => isset( $rule['stacking_mode'] ) ? sanitize_text_field( $rule['stacking_mode'] ) : 'add',
+						// New fields for per-rule valuation and compound bases (v1.2.0).
+						'rule_id'          => ! empty( $rule['rule_id'] )
+							? sanitize_text_field( $rule['rule_id'] )
+							: 'rule_' . wp_generate_uuid4(),
+						'valuation_method' => in_array( $rule['valuation_method'] ?? '', array( 'inherit', 'fob', 'cif', 'cif_insurance' ), true )
+							? $rule['valuation_method']
+							: 'inherit',
+						'base_includes'    => isset( $rule['base_includes'] ) && is_array( $rule['base_includes'] )
+							? array_values( array_unique( array_map( 'sanitize_text_field', $rule['base_includes'] ) ) )
+							: array(),
 					);
 
 					// Only add if either old country field or new to_country field is set.
@@ -261,6 +271,9 @@ class CFWC_Settings {
 				}
 			}
 		}
+
+		// Normalize all rules before saving.
+		$rules = self::migrate_rules( $rules );
 
 		// Save rules.
 		update_option( 'cfwc_rules', $rules );
@@ -276,6 +289,44 @@ class CFWC_Settings {
 
 		// Don't add settings error here - let WooCommerce handle the success message.
 		// to avoid conflicts with their redirect process.
+	}
+
+	/**
+	 * Migrate rules to ensure all required fields are present.
+	 *
+	 * Normalizes legacy rules by adding missing fields with safe defaults.
+	 *
+	 * @since 1.2.0
+	 * @param array $rules Rules to migrate.
+	 * @return array Migrated rules.
+	 */
+	public static function migrate_rules( $rules ) {
+		if ( ! is_array( $rules ) ) {
+			return array();
+		}
+
+		foreach ( $rules as $index => $rule ) {
+			if ( ! is_array( $rule ) ) {
+				continue;
+			}
+
+			// Ensure rule_id exists.
+			if ( empty( $rule['rule_id'] ) ) {
+				$rules[ $index ]['rule_id'] = 'rule_' . wp_generate_uuid4();
+			}
+
+			// Ensure valuation_method exists.
+			if ( empty( $rule['valuation_method'] ) || ! in_array( $rule['valuation_method'], array( 'inherit', 'fob', 'cif', 'cif_insurance' ), true ) ) {
+				$rules[ $index ]['valuation_method'] = 'inherit';
+			}
+
+			// Ensure base_includes exists.
+			if ( ! isset( $rule['base_includes'] ) || ! is_array( $rule['base_includes'] ) ) {
+				$rules[ $index ]['base_includes'] = array();
+			}
+		}
+
+		return $rules;
 	}
 
 	/**

--- a/includes/class-cfwc-settings.php
+++ b/includes/class-cfwc-settings.php
@@ -292,6 +292,11 @@ class CFWC_Settings {
 			CFWC_Calculator::clear_cache();
 		}
 
+		// Reset the cycle-error flag — the rule set just changed, so any
+		// previous dependency-error notice is stale and should be re-derived
+		// on the next calculator run rather than flashed against new data.
+		delete_transient( 'cfwc_rules_dependency_error' );
+
 		// Clear all caches.
 		wp_cache_flush();
 

--- a/includes/class-cfwc-settings.php
+++ b/includes/class-cfwc-settings.php
@@ -292,10 +292,10 @@ class CFWC_Settings {
 			CFWC_Calculator::clear_cache();
 		}
 
-		// Reset the cycle-error flag — the rule set just changed, so any
-		// previous dependency-error notice is stale and should be re-derived
-		// on the next calculator run rather than flashed against new data.
-		delete_transient( 'cfwc_rules_dependency_error' );
+		// Re-derive the cycle-error notice from the just-saved rules so the
+		// admin warning reflects the current state instead of waiting for a
+		// cart calculation to set or clear it.
+		CFWC_Calculator::refresh_cycle_notice( $rules );
 
 		// Clear all caches.
 		wp_cache_flush();

--- a/includes/class-cfwc-templates.php
+++ b/includes/class-cfwc-templates.php
@@ -933,24 +933,30 @@ class CFWC_Templates {
 				'description' => __( 'UK import VAT (20%) and duty for international shipments', 'customs-fees-for-woocommerce' ),
 				'rules'       => array(
 					array(
+						'rule_id'        => 'uk_vat_vat',
 						'country'        => 'GB',
-						'origin_country' => '',  // Applies to all origins.
+						'origin_country' => '',
 						'type'           => 'percentage',
 						'rate'           => 20,
 						'amount'         => 0,
 						'label'          => __( 'UK VAT (Import)', 'customs-fees-for-woocommerce' ),
 						'taxable'        => false,
 						'tax_class'      => '',
+						'valuation_method' => 'cif',
+						'base_includes'  => array( 'uk_vat_duty' ),
 					),
 					array(
+						'rule_id'        => 'uk_vat_duty',
 						'country'        => 'GB',
-						'origin_country' => '',  // Applies to all origins.
+						'origin_country' => '',
 						'type'           => 'percentage',
 						'rate'           => 5,
 						'amount'         => 0,
 						'label'          => __( 'UK Duty (Import)', 'customs-fees-for-woocommerce' ),
 						'taxable'        => false,
 						'tax_class'      => '',
+						'valuation_method' => 'cif',
+						'base_includes'  => array(),
 					),
 				),
 			),
@@ -959,24 +965,30 @@ class CFWC_Templates {
 				'description' => __( 'Canadian GST and import duties', 'customs-fees-for-woocommerce' ),
 				'rules'       => array(
 					array(
+						'rule_id'        => 'canada_gst_gst',
 						'country'        => 'CA',
-						'origin_country' => '',  // Applies to all origins.
+						'origin_country' => '',
 						'type'           => 'percentage',
 						'rate'           => 5,
 						'amount'         => 0,
 						'label'          => __( 'Canada GST (Import)', 'customs-fees-for-woocommerce' ),
 						'taxable'        => false,
 						'tax_class'      => '',
+						'valuation_method' => 'cif',
+						'base_includes'  => array( 'canada_gst_duty' ),
 					),
 					array(
+						'rule_id'        => 'canada_gst_duty',
 						'country'        => 'CA',
-						'origin_country' => '',  // Applies to all origins.
+						'origin_country' => '',
 						'type'           => 'percentage',
 						'rate'           => 8,
 						'amount'         => 0,
 						'label'          => __( 'Canada Duty (Import)', 'customs-fees-for-woocommerce' ),
 						'taxable'        => false,
 						'tax_class'      => '',
+						'valuation_method' => 'fob',
+						'base_includes'  => array(),
 					),
 				),
 			),
@@ -1173,18 +1185,98 @@ class CFWC_Templates {
 			),
 
 			'australia_gst'            => array(
-				'name'        => __( 'Australia GST', 'customs-fees-for-woocommerce' ),
-				'description' => __( 'Australian GST (10%) on imported goods', 'customs-fees-for-woocommerce' ),
+				'name'        => __( 'Australia GST & Duty', 'customs-fees-for-woocommerce' ),
+				'description' => __( 'Australian GST (10%) and duty on imported goods', 'customs-fees-for-woocommerce' ),
 				'rules'       => array(
 					array(
+						'rule_id'        => 'aus_gst',
 						'country'        => 'AU',
-						'origin_country' => '',  // Applies to all origins.
+						'origin_country' => '',
 						'type'           => 'percentage',
 						'rate'           => 10,
 						'amount'         => 0,
 						'label'          => __( 'Australia GST (Import)', 'customs-fees-for-woocommerce' ),
 						'taxable'        => false,
 						'tax_class'      => '',
+						'valuation_method' => 'cif',
+						'base_includes'  => array( 'aus_duty' ),
+					),
+					array(
+						'rule_id'        => 'aus_duty',
+						'country'        => 'AU',
+						'origin_country' => '',
+						'type'           => 'percentage',
+						'rate'           => 5,
+						'amount'         => 0,
+						'label'          => __( 'Australia Duty (Import)', 'customs-fees-for-woocommerce' ),
+						'taxable'        => false,
+						'tax_class'      => '',
+						'valuation_method' => 'fob',
+						'base_includes'  => array(),
+					),
+				),
+			),
+			'new_zealand_gst'          => array(
+				'name'        => __( 'New Zealand GST & Duty', 'customs-fees-for-woocommerce' ),
+				'description' => __( 'New Zealand GST (15%) and duty on imported goods', 'customs-fees-for-woocommerce' ),
+				'rules'       => array(
+					array(
+						'rule_id'        => 'nz_gst',
+						'country'        => 'NZ',
+						'origin_country' => '',
+						'type'           => 'percentage',
+						'rate'           => 15,
+						'amount'         => 0,
+						'label'          => __( 'New Zealand GST (Import)', 'customs-fees-for-woocommerce' ),
+						'taxable'        => false,
+						'tax_class'      => '',
+						'valuation_method' => 'cif',
+						'base_includes'  => array( 'nz_duty' ),
+					),
+					array(
+						'rule_id'        => 'nz_duty',
+						'country'        => 'NZ',
+						'origin_country' => '',
+						'type'           => 'percentage',
+						'rate'           => 5,
+						'amount'         => 0,
+						'label'          => __( 'New Zealand Duty (Import)', 'customs-fees-for-woocommerce' ),
+						'taxable'        => false,
+						'tax_class'      => '',
+						'valuation_method' => 'fob',
+						'base_includes'  => array(),
+					),
+				),
+			),
+			'eu_vat'                   => array(
+				'name'        => __( 'EU VAT & Duty', 'customs-fees-for-woocommerce' ),
+				'description' => __( 'EU import VAT (20%) and duty for international shipments', 'customs-fees-for-woocommerce' ),
+				'rules'       => array(
+					array(
+						'rule_id'        => 'eu_vat_vat',
+						'country'        => 'EU',
+						'origin_country' => '',
+						'type'           => 'percentage',
+						'rate'           => 20,
+						'amount'         => 0,
+						'label'          => __( 'EU VAT (Import)', 'customs-fees-for-woocommerce' ),
+						'taxable'        => false,
+						'tax_class'      => '',
+						'valuation_method' => 'cif',
+						'base_includes'  => array( 'eu_vat_duty' ),
+					),
+					array(
+						'rule_id'        => 'eu_vat_duty',
+						'country'        => 'EU',
+						'origin_country' => '',
+						'type'           => 'percentage',
+						'rate'           => 5,
+						'amount'         => 0,
+						'label'          => __( 'EU Duty (Import)', 'customs-fees-for-woocommerce' ),
+						'taxable'        => false,
+						'tax_class'      => '',
+						'valuation_method' => 'cif',
+						'base_includes'  => array(),
 					),
 				),
 			),
@@ -1247,11 +1339,16 @@ class CFWC_Templates {
 		$added_count     = 0;
 		$duplicate_count = 0;
 
+		// Normalize template rules before applying.
+		$template_rules = class_exists( 'CFWC_Settings' ) && method_exists( 'CFWC_Settings', 'migrate_rules' )
+			? CFWC_Settings::migrate_rules( $template['rules'] )
+			: $template['rules'];
+
 		if ( $append ) {
 			// Check for duplicates when appending.
 			$rules = $existing_rules;
 
-			foreach ( $template['rules'] as $new_rule ) {
+			foreach ( $template_rules as $new_rule ) {
 				// Convert old format to new format if needed.
 				if ( ! isset( $new_rule['from_country'] ) && isset( $new_rule['origin_country'] ) ) {
 					$new_rule['from_country'] = $new_rule['origin_country'];
@@ -1297,8 +1394,8 @@ class CFWC_Templates {
 			}
 		} else {
 			// Replace all rules.
-			$rules       = $template['rules'];
-			$added_count = count( $template['rules'] );
+			$rules       = $template_rules;
+			$added_count = count( $template_rules );
 		}
 
 		update_option( 'cfwc_rules', $rules );

--- a/includes/class-cfwc-templates.php
+++ b/includes/class-cfwc-templates.php
@@ -1446,8 +1446,7 @@ class CFWC_Templates {
 		update_option( 'cfwc_rules', $rules );
 
 		// Clear cache.
-		$calculator = new CFWC_Calculator();
-		$calculator->clear_cache();
+		CFWC_Calculator::clear_cache();
 
 		return array(
 			'success'     => true,

--- a/includes/class-cfwc-templates.php
+++ b/includes/class-cfwc-templates.php
@@ -1348,6 +1348,32 @@ class CFWC_Templates {
 			// Check for duplicates when appending.
 			$rules = $existing_rules;
 
+			// Build set of existing rule_ids so we can suffix collisions and
+			// rewrite intra-batch base_includes references to the new IDs.
+			$existing_rule_ids = array();
+			foreach ( $existing_rules as $existing_rule ) {
+				if ( ! empty( $existing_rule['rule_id'] ) ) {
+					$existing_rule_ids[ $existing_rule['rule_id'] ] = true;
+				}
+			}
+
+			$id_remap = array();
+			foreach ( $template_rules as $new_rule ) {
+				$original_id = $new_rule['rule_id'] ?? '';
+				if ( '' === $original_id ) {
+					continue;
+				}
+				if ( isset( $existing_rule_ids[ $original_id ] ) ) {
+					$suffix    = 2;
+					$candidate = $original_id . '_' . $suffix;
+					while ( isset( $existing_rule_ids[ $candidate ] ) || isset( $id_remap[ $candidate ] ) ) {
+						++$suffix;
+						$candidate = $original_id . '_' . $suffix;
+					}
+					$id_remap[ $original_id ] = $candidate;
+				}
+			}
+
 			foreach ( $template_rules as $new_rule ) {
 				// Convert old format to new format if needed.
 				if ( ! isset( $new_rule['from_country'] ) && isset( $new_rule['origin_country'] ) ) {
@@ -1355,6 +1381,22 @@ class CFWC_Templates {
 				}
 				if ( ! isset( $new_rule['to_country'] ) && isset( $new_rule['country'] ) ) {
 					$new_rule['to_country'] = $new_rule['country'];
+				}
+
+				// Apply rule_id remap (collision-suffixed) and rewrite
+				// base_includes references that point at remapped sibling
+				// rules so dependency edges within this batch stay intact.
+				$original_id = $new_rule['rule_id'] ?? '';
+				if ( '' !== $original_id && isset( $id_remap[ $original_id ] ) ) {
+					$new_rule['rule_id'] = $id_remap[ $original_id ];
+				}
+				if ( ! empty( $new_rule['base_includes'] ) && is_array( $new_rule['base_includes'] ) ) {
+					$new_rule['base_includes'] = array_map(
+						function ( $dep_id ) use ( $id_remap ) {
+							return $id_remap[ $dep_id ] ?? $dep_id;
+						},
+						$new_rule['base_includes']
+					);
 				}
 
 				// Check if rule already exists (same country pair + label combination).
@@ -1389,6 +1431,9 @@ class CFWC_Templates {
 
 				if ( ! $is_duplicate ) {
 					$rules[] = $new_rule;
+					if ( ! empty( $new_rule['rule_id'] ) ) {
+						$existing_rule_ids[ $new_rule['rule_id'] ] = true;
+					}
 					++$added_count;
 				}
 			}

--- a/includes/class-cfwc-templates.php
+++ b/includes/class-cfwc-templates.php
@@ -1448,6 +1448,11 @@ class CFWC_Templates {
 		// Clear cache.
 		CFWC_Calculator::clear_cache();
 
+		// Re-derive the cycle-error notice from the merged rule set. A
+		// template can introduce or resolve cycles depending on what it
+		// adds or replaces, so admin needs to reflect that immediately.
+		CFWC_Calculator::refresh_cycle_notice( $rules );
+
 		return array(
 			'success'     => true,
 			'added'       => $added_count,

--- a/includes/class-cfwc-templates.php
+++ b/includes/class-cfwc-templates.php
@@ -1345,11 +1345,17 @@ class CFWC_Templates {
 			: $template['rules'];
 
 		if ( $append ) {
-			// Check for duplicates when appending.
-			$rules = $existing_rules;
-
-			// Build set of existing rule_ids so we can suffix collisions and
-			// rewrite intra-batch base_includes references to the new IDs.
+			// Two-pass append. Pass 1 normalizes each incoming rule and
+			// classifies it as either a true duplicate of an existing rule
+			// (same from/to/label) or a colliding rule_id that needs
+			// suffixing, populating a single $id_remap that covers both
+			// cases. Pass 2 applies the remap to rule_id and base_includes
+			// and appends the survivors. Doing this in two passes is what
+			// lets a compound preset like "Canada GST & Duty" remap the
+			// GST rule's base_includes onto a pre-existing duty rule with a
+			// different rule_id, regardless of the order the preset lists
+			// them in.
+			$rules             = $existing_rules;
 			$existing_rule_ids = array();
 			foreach ( $existing_rules as $existing_rule ) {
 				if ( ! empty( $existing_rule['rule_id'] ) ) {
@@ -1357,16 +1363,53 @@ class CFWC_Templates {
 				}
 			}
 
-			$id_remap = array();
-			foreach ( $template_rules as $new_rule ) {
-				$original_id = $new_rule['rule_id'] ?? '';
-				if ( '' === $original_id ) {
-					continue;
+			$id_remap     = array();
+			$is_duplicate = array();
+			$normalized   = array();
+
+			foreach ( $template_rules as $index => $new_rule ) {
+				if ( ! isset( $new_rule['from_country'] ) && isset( $new_rule['origin_country'] ) ) {
+					$new_rule['from_country'] = $new_rule['origin_country'];
 				}
-				if ( isset( $existing_rule_ids[ $original_id ] ) ) {
+				if ( ! isset( $new_rule['to_country'] ) && isset( $new_rule['country'] ) ) {
+					$new_rule['to_country'] = $new_rule['country'];
+				}
+				$normalized[ $index ] = $new_rule;
+
+				$new_from    = $new_rule['from_country'] ?? '';
+				$new_to      = $new_rule['to_country'] ?? '';
+				$new_label   = $new_rule['label'] ?? '';
+				$original_id = $new_rule['rule_id'] ?? '';
+
+				// Exact-duplicate detection: same from/to/label as an
+				// existing rule. Record the existing rule's id so any
+				// sibling that depends on this template rule can be
+				// rewired to the existing one.
+				foreach ( $existing_rules as $existing_rule ) {
+					$existing_from  = $existing_rule['from_country'] ?? $existing_rule['origin_country'] ?? $existing_rule['country'] ?? '';
+					$existing_to    = $existing_rule['to_country'] ?? $existing_rule['country'] ?? '';
+					$existing_label = $existing_rule['label'] ?? '';
+
+					if ( $existing_from === $new_from &&
+						$existing_to === $new_to &&
+						$existing_label === $new_label ) {
+						$is_duplicate[ $index ] = true;
+						if ( '' !== $original_id && ! empty( $existing_rule['rule_id'] ) ) {
+							$id_remap[ $original_id ] = $existing_rule['rule_id'];
+						}
+						break;
+					}
+				}
+
+				// rule_id collision suffixing for the survivors. A rule
+				// already marked as an exact duplicate doesn't need a
+				// suffix — it will be skipped — but its id is still in
+				// $id_remap above so dependents resolve to the existing
+				// rule's id.
+				if ( ! isset( $is_duplicate[ $index ] ) && '' !== $original_id && isset( $existing_rule_ids[ $original_id ] ) ) {
 					$suffix    = 2;
 					$candidate = $original_id . '_' . $suffix;
-					while ( isset( $existing_rule_ids[ $candidate ] ) || isset( $id_remap[ $candidate ] ) ) {
+					while ( isset( $existing_rule_ids[ $candidate ] ) || in_array( $candidate, $id_remap, true ) ) {
 						++$suffix;
 						$candidate = $original_id . '_' . $suffix;
 					}
@@ -1374,18 +1417,7 @@ class CFWC_Templates {
 				}
 			}
 
-			foreach ( $template_rules as $new_rule ) {
-				// Convert old format to new format if needed.
-				if ( ! isset( $new_rule['from_country'] ) && isset( $new_rule['origin_country'] ) ) {
-					$new_rule['from_country'] = $new_rule['origin_country'];
-				}
-				if ( ! isset( $new_rule['to_country'] ) && isset( $new_rule['country'] ) ) {
-					$new_rule['to_country'] = $new_rule['country'];
-				}
-
-				// Apply rule_id remap (collision-suffixed) and rewrite
-				// base_includes references that point at remapped sibling
-				// rules so dependency edges within this batch stay intact.
+			foreach ( $normalized as $index => $new_rule ) {
 				$original_id = $new_rule['rule_id'] ?? '';
 				if ( '' !== $original_id && isset( $id_remap[ $original_id ] ) ) {
 					$new_rule['rule_id'] = $id_remap[ $original_id ];
@@ -1399,43 +1431,16 @@ class CFWC_Templates {
 					);
 				}
 
-				// Check if rule already exists (same country pair + label combination).
-				$is_duplicate = false;
-				foreach ( $existing_rules as $existing_rule ) {
-					$existing_from       = $existing_rule['from_country'] ?? $existing_rule['origin_country'] ?? $existing_rule['country'] ?? '';
-					$existing_to         = $existing_rule['to_country'] ?? $existing_rule['country'] ?? '';
-					$new_from            = $new_rule['from_country'] ?? $new_rule['origin_country'] ?? $new_rule['country'] ?? '';
-					$new_to              = $new_rule['to_country'] ?? $new_rule['country'] ?? '';
-					$existing_match_type = $existing_rule['match_type'] ?? 'all';
-					$new_match_type      = $new_rule['match_type'] ?? 'all';
-
-					// Check for exact duplicate.
-					if ( $existing_from === $new_from &&
-						$existing_to === $new_to &&
-						$existing_rule['label'] === $new_rule['label'] ) {
-						$is_duplicate = true;
-						++$duplicate_count;
-						break;
-					}
-
-					// Check for conflicting general rules (both applying to all products from all origins).
-					if ( empty( $existing_from ) && empty( $new_from ) &&
-						$new_to === $existing_to &&
-						'all' === $existing_match_type && 'all' === $new_match_type ) {
-						// Two general rules for the same destination - skip the new one.
-						$is_duplicate = true;
-						++$duplicate_count;
-						break;
-					}
+				if ( isset( $is_duplicate[ $index ] ) ) {
+					++$duplicate_count;
+					continue;
 				}
 
-				if ( ! $is_duplicate ) {
-					$rules[] = $new_rule;
-					if ( ! empty( $new_rule['rule_id'] ) ) {
-						$existing_rule_ids[ $new_rule['rule_id'] ] = true;
-					}
-					++$added_count;
+				$rules[] = $new_rule;
+				if ( ! empty( $new_rule['rule_id'] ) ) {
+					$existing_rule_ids[ $new_rule['rule_id'] ] = true;
 				}
+				++$added_count;
 			}
 		} else {
 			// Replace all rules.

--- a/includes/class-customs-fees-woocommerce.php
+++ b/includes/class-customs-fees-woocommerce.php
@@ -142,6 +142,18 @@ final class Customs_Fees_WooCommerce {
 			// Clear the activation flag.
 			delete_option( 'cfwc_activated' );
 		}
+
+		// Handle upgrades from versions before 1.2.0.
+		$current_version = get_option( 'cfwc_version', '1.0.0' );
+		if ( version_compare( $current_version, '1.2.0', '<' ) ) {
+			$rules = get_option( 'cfwc_rules', array() );
+			if ( class_exists( 'CFWC_Settings' ) && method_exists( 'CFWC_Settings', 'migrate_rules' ) ) {
+				$rules = CFWC_Settings::migrate_rules( $rules );
+				update_option( 'cfwc_rules', $rules );
+			}
+			update_option( 'cfwc_version', '1.2.0' );
+			delete_transient( 'cfwc_rules_cache' );
+		}
 	}
 
 	/**

--- a/includes/class-customs-fees-woocommerce.php
+++ b/includes/class-customs-fees-woocommerce.php
@@ -63,6 +63,11 @@ final class Customs_Fees_WooCommerce {
 		// Handle activation on admin_init like AutomateWoo does.
 		add_action( 'admin_init', array( $this, 'maybe_activate' ), 20 );
 
+		// Run data migrations on every request so frontend cart calculations
+		// see migrated rules even before any admin user logs in. Guarded by
+		// option flags so the work only runs once per site.
+		add_action( 'init', array( $this, 'maybe_run_migrations' ), 5 );
+
 		// Initialize the plugin.
 		$this->init();
 	}
@@ -143,14 +148,26 @@ final class Customs_Fees_WooCommerce {
 			delete_option( 'cfwc_activated' );
 		}
 
-		// Handle upgrades that introduced new per-rule fields (rule_id,
-		// valuation_method, base_includes). Run once per upgrade by gating
-		// on a dedicated option independent of the plugin version, so
-		// patch-level bumps do not re-trigger and the option always reflects
-		// the running plugin version after migration.
+		// Per-rule field migration is now run unconditionally on `init` via
+		// maybe_run_migrations() so frontend requests see migrated data
+		// before any admin user logs in.
+	}
+
+	/**
+	 * Run idempotent data migrations on every request.
+	 *
+	 * Guarded by dedicated option flags so each migration runs at most once
+	 * per site. Hooked early on `init` so the calculator sees migrated rules
+	 * during checkout calculations even before any admin page is loaded.
+	 *
+	 * @since 1.2.0
+	 */
+	public function maybe_run_migrations() {
+		// Migration: per-rule valuation fields (rule_id, valuation_method,
+		// base_includes) introduced for the per-rule valuation feature.
 		if ( ! get_option( 'cfwc_rules_migrated_perrule_valuation' ) ) {
-			$rules = get_option( 'cfwc_rules', array() );
 			if ( class_exists( 'CFWC_Settings' ) && method_exists( 'CFWC_Settings', 'migrate_rules' ) ) {
+				$rules = get_option( 'cfwc_rules', array() );
 				$rules = CFWC_Settings::migrate_rules( $rules );
 				update_option( 'cfwc_rules', $rules );
 			}
@@ -158,8 +175,8 @@ final class Customs_Fees_WooCommerce {
 			delete_transient( 'cfwc_rules_cache' );
 		}
 
-		// Keep cfwc_version aligned with the running plugin so future migrations
-		// can gate on version_compare against the real release number.
+		// Keep cfwc_version aligned with the running plugin so future
+		// migrations can gate on version_compare against the real release.
 		if ( defined( 'CFWC_VERSION' ) && get_option( 'cfwc_version' ) !== CFWC_VERSION ) {
 			update_option( 'cfwc_version', CFWC_VERSION );
 		}

--- a/includes/class-customs-fees-woocommerce.php
+++ b/includes/class-customs-fees-woocommerce.php
@@ -143,16 +143,25 @@ final class Customs_Fees_WooCommerce {
 			delete_option( 'cfwc_activated' );
 		}
 
-		// Handle upgrades from versions before 1.2.0.
-		$current_version = get_option( 'cfwc_version', '1.0.0' );
-		if ( version_compare( $current_version, '1.2.0', '<' ) ) {
+		// Handle upgrades that introduced new per-rule fields (rule_id,
+		// valuation_method, base_includes). Run once per upgrade by gating
+		// on a dedicated option independent of the plugin version, so
+		// patch-level bumps do not re-trigger and the option always reflects
+		// the running plugin version after migration.
+		if ( ! get_option( 'cfwc_rules_migrated_perrule_valuation' ) ) {
 			$rules = get_option( 'cfwc_rules', array() );
 			if ( class_exists( 'CFWC_Settings' ) && method_exists( 'CFWC_Settings', 'migrate_rules' ) ) {
 				$rules = CFWC_Settings::migrate_rules( $rules );
 				update_option( 'cfwc_rules', $rules );
 			}
-			update_option( 'cfwc_version', '1.2.0' );
+			update_option( 'cfwc_rules_migrated_perrule_valuation', 1 );
 			delete_transient( 'cfwc_rules_cache' );
+		}
+
+		// Keep cfwc_version aligned with the running plugin so future migrations
+		// can gate on version_compare against the real release number.
+		if ( defined( 'CFWC_VERSION' ) && get_option( 'cfwc_version' ) !== CFWC_VERSION ) {
+			update_option( 'cfwc_version', CFWC_VERSION );
 		}
 	}
 

--- a/includes/class-customs-fees-woocommerce.php
+++ b/includes/class-customs-fees-woocommerce.php
@@ -165,13 +165,19 @@ final class Customs_Fees_WooCommerce {
 	public function maybe_run_migrations() {
 		// Migration: per-rule valuation fields (rule_id, valuation_method,
 		// base_includes) introduced for the per-rule valuation feature.
-		if ( ! get_option( 'cfwc_rules_migrated_perrule_valuation' ) ) {
+		//
+		// add_option() is atomic at the DB layer: only the first concurrent
+		// request after upgrade succeeds, so the migration body runs exactly
+		// once even if multiple PHP workers hit init() in parallel. Using a
+		// non-atomic get_option/update_option pair here previously allowed
+		// concurrent workers to each read the pre-migration rules and race
+		// their update_option('cfwc_rules', ...) writes.
+		if ( add_option( 'cfwc_rules_migrated_perrule_valuation', 1 ) ) {
 			if ( class_exists( 'CFWC_Settings' ) && method_exists( 'CFWC_Settings', 'migrate_rules' ) ) {
 				$rules = get_option( 'cfwc_rules', array() );
 				$rules = CFWC_Settings::migrate_rules( $rules );
 				update_option( 'cfwc_rules', $rules );
 			}
-			update_option( 'cfwc_rules_migrated_perrule_valuation', 1 );
 			delete_transient( 'cfwc_rules_cache' );
 		}
 

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -2,7 +2,7 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Customs Fees for WooCommerce 1.2.1\n"
+"Project-Id-Version: Customs Fees for WooCommerce 1.1.7\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
 "POT-Creation-Date: 2026-04-27 15:42:21+00:00\n"

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Customs Fees for WooCommerce 1.1.5\n"
+"Project-Id-Version: Customs Fees for WooCommerce 1.2.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
-"POT-Creation-Date: 2026-02-05 03:29:56+00:00\n"
+"POT-Creation-Date: 2026-04-27 15:42:21+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -14,74 +14,78 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: node-wp-i18n 1.2.8\n"
 
-#: includes/admin/class-cfwc-admin.php:70
-#: includes/admin/class-cfwc-admin.php:97
-#: includes/admin/class-cfwc-admin.php:185 includes/class-cfwc-display.php:68
+#: includes/admin/class-cfwc-admin.php:62
+msgid "Customs Fees Warning"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:81
+#: includes/admin/class-cfwc-admin.php:108
+#: includes/admin/class-cfwc-admin.php:196 includes/class-cfwc-display.php:68
 #: includes/class-cfwc-display.php:145 includes/class-cfwc-display.php:171
 #: includes/class-cfwc-display.php:225 includes/class-cfwc-display.php:383
 #: includes/class-cfwc-loader.php:279 includes/class-cfwc-settings.php:65
 msgid "Customs & Import Fees"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:112
+#: includes/admin/class-cfwc-admin.php:123
 msgid "Fees Breakdown:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:122
+#: includes/admin/class-cfwc-admin.php:133
 msgid "Total:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:125
+#: includes/admin/class-cfwc-admin.php:136
 msgid "Total Customs Fees:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:127
+#: includes/admin/class-cfwc-admin.php:138
 msgid "These fees were calculated based on the destination country and cart value."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:129
+#: includes/admin/class-cfwc-admin.php:140
 msgid "No customs fees applied to this order."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:136
+#: includes/admin/class-cfwc-admin.php:147
 msgid "Product Customs Information:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:158
-#: includes/admin/class-cfwc-admin.php:502 includes/class-cfwc-display.php:295
+#: includes/admin/class-cfwc-admin.php:169
+#: includes/admin/class-cfwc-admin.php:519 includes/class-cfwc-display.php:295
 #: includes/class-cfwc-display.php:342
 msgid "HS Code:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:165
-#: includes/admin/class-cfwc-admin.php:509 includes/class-cfwc-display.php:301
+#: includes/admin/class-cfwc-admin.php:176
+#: includes/admin/class-cfwc-admin.php:526 includes/class-cfwc-display.php:301
 #: includes/class-cfwc-display.php:348
 msgid "Origin:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:190
+#: includes/admin/class-cfwc-admin.php:201
 msgid "HS/Tariff Code"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:191
+#: includes/admin/class-cfwc-admin.php:202
 msgid "e.g., 6109.10 or 6109.10.0012"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:193
+#: includes/admin/class-cfwc-admin.php:204
 msgid ""
 "Harmonized System code for customs classification. This helps calculate "
 "accurate import duties."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:200
+#: includes/admin/class-cfwc-admin.php:211
 msgid "You can "
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:202
+#: includes/admin/class-cfwc-admin.php:213
 msgid "find HS codes here"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:229
+#: includes/admin/class-cfwc-admin.php:240
 #: includes/admin/class-cfwc-onboarding.php:281
 #: includes/admin/class-cfwc-onboarding.php:361
 #: includes/class-cfwc-export-import.php:59
@@ -92,174 +96,200 @@ msgstr ""
 msgid "Country of Origin"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:231
+#: includes/admin/class-cfwc-admin.php:242
 msgid ""
 "Select the country where this product was manufactured. This determines "
 "which customs rules apply."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:232
-#: includes/admin/class-cfwc-admin.php:236
-#: includes/admin/class-cfwc-admin.php:341
-#: includes/admin/class-cfwc-admin.php:426
+#: includes/admin/class-cfwc-admin.php:243
+#: includes/admin/class-cfwc-admin.php:247
+#: includes/admin/class-cfwc-admin.php:352
+#: includes/admin/class-cfwc-admin.php:437
 msgid "Select a country"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:427
+#: includes/admin/class-cfwc-admin.php:438
 msgid "Please select a preset first."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:428
+#: includes/admin/class-cfwc-admin.php:439
 #: includes/admin/views/rules-section.php:583
 msgid "Import Preset Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:429
+#: includes/admin/class-cfwc-admin.php:440
 #: includes/admin/views/rules-section.php:585
 msgid "Add to Existing Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:430
+#: includes/admin/class-cfwc-admin.php:441
 msgid "Adding preset rules..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:431
+#: includes/admin/class-cfwc-admin.php:442
 msgid "Replacing all rules with preset..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:432
+#: includes/admin/class-cfwc-admin.php:443
 msgid "Click again to confirm"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:433
+#: includes/admin/class-cfwc-admin.php:444
 #: includes/admin/views/rules-section.php:590
 msgid "Replace All Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:434
+#: includes/admin/class-cfwc-admin.php:445
 msgid "No rules to delete."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:435
+#: includes/admin/class-cfwc-admin.php:446
 msgid "All rules deleted. Remember to click \"Save changes\" to persist."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:436
+#: includes/admin/class-cfwc-admin.php:447
 #: includes/admin/views/rules-section.php:689
 msgid "Delete All Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:437
+#: includes/admin/class-cfwc-admin.php:448
 msgid "Warning: This will delete all existing rules. Click again to confirm."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:438
+#: includes/admin/class-cfwc-admin.php:449
 msgid "Click to Confirm Delete"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:439
+#: includes/admin/class-cfwc-admin.php:450
 msgid "Preset applied successfully!"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:440
+#: includes/admin/class-cfwc-admin.php:451
 msgid "Remember to click \"Save changes\" to persist these rules."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:441
-#: includes/class-cfwc-templates.php:1372
+#: includes/admin/class-cfwc-admin.php:452
+#: includes/class-cfwc-templates.php:1513
 msgid "Failed to apply preset."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:442
+#: includes/admin/class-cfwc-admin.php:453
 msgid "An error occurred while applying the preset."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:443
+#: includes/admin/class-cfwc-admin.php:454
 msgid "Check browser console for details."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:444
+#: includes/admin/class-cfwc-admin.php:455
 msgid "Dismiss this notice"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:445
+#: includes/admin/class-cfwc-admin.php:456
 msgid "Select country..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:446
+#: includes/admin/class-cfwc-admin.php:457
 msgid "All Origins"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:447
+#: includes/admin/class-cfwc-admin.php:458
 msgid "EU Countries"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:448
+#: includes/admin/class-cfwc-admin.php:459
 msgid "Specific Country"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:449
+#: includes/admin/class-cfwc-admin.php:460
 msgid "Fee label"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:450
+#: includes/admin/class-cfwc-admin.php:461
 msgid "Choose a country..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:451
+#: includes/admin/class-cfwc-admin.php:462
 msgid "Choose origin..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:452
+#: includes/admin/class-cfwc-admin.php:463
 msgid "Percentage"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:453
+#: includes/admin/class-cfwc-admin.php:464
 msgid "Flat"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:454
+#: includes/admin/class-cfwc-admin.php:465
 msgid "Save"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:455
+#: includes/admin/class-cfwc-admin.php:466
 msgid "Cancel"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:456
-#: includes/admin/views/rules-section.php:853
+#: includes/admin/class-cfwc-admin.php:467
+#: includes/admin/views/rules-section.php:891
 msgid "Edit"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:457
-#: includes/admin/views/rules-section.php:856
+#: includes/admin/class-cfwc-admin.php:468
+#: includes/admin/views/rules-section.php:894
 msgid "Delete"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:458
+#: includes/admin/class-cfwc-admin.php:469
 msgid "Rule saved. Remember to click \"Save changes\" to persist."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:459
+#: includes/admin/class-cfwc-admin.php:470
 msgid "Rule deleted successfully. Remember to click \"Save changes\" to persist."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:460
+#: includes/admin/class-cfwc-admin.php:471
 msgid "Click the delete button again to confirm deletion."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:461
-#: includes/admin/views/rules-section.php:863
+#: includes/admin/class-cfwc-admin.php:472
+#: includes/admin/views/rules-section.php:901
 msgid "No rules configured. Use the preset loader above or add rules manually."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:462
+#: includes/admin/class-cfwc-admin.php:473
 #: includes/class-cfwc-products-variation-support.php:64
 #: includes/class-cfwc-products-variation-support.php:87
 msgid "Not set"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:535
+#: includes/admin/class-cfwc-admin.php:474
+msgid "Valuation method"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:475
+#: includes/admin/views/rules-section.php:711
+msgid "Depends on"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:476
+msgid "Inherit global"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:477
+#: includes/admin/views/rules-section.php:829
+msgid "Overrides global valuation"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:478
+msgid "Select fees to include in base"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:479
+msgid "Rule dependency cycle detected. Some rules may not calculate correctly."
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:552
 #: includes/admin/class-cfwc-onboarding.php:274
 #: includes/admin/class-cfwc-onboarding.php:355
 #: includes/class-cfwc-emails.php:186 includes/class-cfwc-export-import.php:58
@@ -271,61 +301,62 @@ msgstr ""
 msgid "HS Code"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:539 includes/class-cfwc-emails.php:201
+#: includes/admin/class-cfwc-admin.php:556 includes/class-cfwc-emails.php:201
 #: includes/class-cfwc-products.php:106
 msgid "Origin"
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:100
+#: includes/admin/class-cfwc-ajax.php:128
 msgid "Rule saved successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:125
+#: includes/admin/class-cfwc-ajax.php:155
 msgid "Invalid rule ID."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:148
+#: includes/admin/class-cfwc-ajax.php:197
 msgid "Rule deleted successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:154
+#: includes/admin/class-cfwc-ajax.php:203
 msgid "Rule not found."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:179
+#: includes/admin/class-cfwc-ajax.php:228
 msgid "Invalid order data."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:204
+#: includes/admin/class-cfwc-ajax.php:252
 msgid "Rules reordered successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:247
+#: includes/admin/class-cfwc-ajax.php:305
 msgid "Export ready for download."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:272
+#: includes/admin/class-cfwc-ajax.php:330
 msgid "No CSV content provided."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:308
+#: includes/admin/class-cfwc-ajax.php:412
 msgid "No valid rules found in CSV."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:330
+#: includes/admin/class-cfwc-ajax.php:433
 #. translators: %d: Number of rules imported
 msgid "%d rules imported successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:357
+#: includes/admin/class-cfwc-ajax.php:460
 msgid "Invalid test parameters."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:393
+#: includes/admin/class-cfwc-ajax.php:543
+#: includes/admin/class-cfwc-ajax.php:568
 msgid "Customs Fee"
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:405
+#: includes/admin/class-cfwc-ajax.php:582
 msgid "Calculation complete."
 msgstr ""
 
@@ -557,7 +588,7 @@ msgid "Rule stacking modes"
 msgstr ""
 
 #: includes/admin/views/rules-section.php:249
-#: includes/admin/views/rules-section.php:824
+#: includes/admin/views/rules-section.php:862
 msgid "Stack"
 msgstr ""
 
@@ -566,7 +597,7 @@ msgid "Adds with other matching rules."
 msgstr ""
 
 #: includes/admin/views/rules-section.php:253
-#: includes/admin/views/rules-section.php:825
+#: includes/admin/views/rules-section.php:863
 msgid "Override"
 msgstr ""
 
@@ -575,7 +606,7 @@ msgid "Replaces lower priority rules."
 msgstr ""
 
 #: includes/admin/views/rules-section.php:257
-#: includes/admin/views/rules-section.php:826
+#: includes/admin/views/rules-section.php:864
 msgid "Exclusive"
 msgstr ""
 
@@ -667,59 +698,79 @@ msgid "Rate"
 msgstr ""
 
 #: includes/admin/views/rules-section.php:710
+msgid "Valuation"
+msgstr ""
+
+#: includes/admin/views/rules-section.php:712
 msgid "Stacking"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:711
+#: includes/admin/views/rules-section.php:713
 msgid "Actions"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:727
+#: includes/admin/views/rules-section.php:729
 msgid "Higher priority rules are checked first (0-100)"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:744
+#: includes/admin/views/rules-section.php:746
 msgid "All → All"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:748
+#: includes/admin/views/rules-section.php:750
 #. translators: %s: destination country name
 msgid "Any → %s"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:752
+#: includes/admin/views/rules-section.php:754
 #. translators: %s: origin country name
 msgid "%s → Any"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:767
-#: includes/admin/views/rules-section.php:804
+#: includes/admin/views/rules-section.php:769
+#: includes/admin/views/rules-section.php:806
 msgid "All Products"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:782
+#: includes/admin/views/rules-section.php:784
 #. translators: %d: number of additional categories
 msgid "+%d more"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:836
+#: includes/admin/views/rules-section.php:824
+msgid "FOB"
+msgstr ""
+
+#: includes/admin/views/rules-section.php:825
+msgid "CIF"
+msgstr ""
+
+#: includes/admin/views/rules-section.php:826
+msgid "CIF + Ins"
+msgstr ""
+
+#: includes/admin/views/rules-section.php:831
+msgid "Global"
+msgstr ""
+
+#: includes/admin/views/rules-section.php:874
 msgid "Adds with other matching rules"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:837
+#: includes/admin/views/rules-section.php:875
 msgid "Replaces lower priority rules"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:838
+#: includes/admin/views/rules-section.php:876
 msgid "Only this rule applies"
 msgstr ""
 
-#: includes/class-cfwc-calculator.php:736
+#: includes/class-cfwc-calculator.php:920
 #. translators: %1$s: destination country, %2$s: origin country
 msgid "Import Fees (%1$s from %2$s)"
 msgstr ""
 
-#: includes/class-cfwc-calculator.php:744
+#: includes/class-cfwc-calculator.php:928
 #. translators: %s: country name
 msgid "Customs & Import Fees (%s)"
 msgstr ""
@@ -730,7 +781,7 @@ msgid "Customs & Import Information"
 msgstr ""
 
 #: includes/class-cfwc-display.php:239 includes/class-cfwc-display.php:250
-#: includes/class-cfwc-settings.php:306
+#: includes/class-cfwc-settings.php:365
 msgid "Estimated import duties and taxes based on destination country."
 msgstr ""
 
@@ -864,11 +915,11 @@ msgstr ""
 msgid "Use parent product"
 msgstr ""
 
-#: includes/class-cfwc-settings.php:146
+#: includes/class-cfwc-settings.php:143
 msgid "Customs & Import Fees Settings"
 msgstr ""
 
-#: includes/class-cfwc-settings.php:292
+#: includes/class-cfwc-settings.php:351
 msgid "All Countries"
 msgstr ""
 
@@ -1133,7 +1184,7 @@ msgstr ""
 msgid "US reciprocal tariff for goods from Switzerland - 39%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:708 includes/class-cfwc-templates.php:996
+#: includes/class-cfwc-templates.php:708 includes/class-cfwc-templates.php:1008
 msgid "US Tariff (Switzerland)"
 msgstr ""
 
@@ -1145,7 +1196,7 @@ msgstr ""
 msgid "US reciprocal tariff for goods from Vietnam - 20%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:727 includes/class-cfwc-templates.php:1102
+#: includes/class-cfwc-templates.php:727 includes/class-cfwc-templates.php:1114
 msgid "US Tariff (Vietnam)"
 msgstr ""
 
@@ -1157,7 +1208,7 @@ msgstr ""
 msgid "US reciprocal tariff for goods from Thailand - 19%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:744 includes/class-cfwc-templates.php:1113
+#: includes/class-cfwc-templates.php:744 includes/class-cfwc-templates.php:1125
 msgid "US Tariff (Thailand)"
 msgstr ""
 
@@ -1169,7 +1220,7 @@ msgstr ""
 msgid "US reciprocal tariff for goods from Indonesia - 19%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:761 includes/class-cfwc-templates.php:1135
+#: includes/class-cfwc-templates.php:761 includes/class-cfwc-templates.php:1147
 msgid "US Tariff (Indonesia)"
 msgstr ""
 
@@ -1289,135 +1340,171 @@ msgstr ""
 msgid "UK import VAT (20%) and duty for international shipments"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:941
+#: includes/class-cfwc-templates.php:942
 msgid "UK VAT (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:951
+#: includes/class-cfwc-templates.php:955
 msgid "UK Duty (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:958
+#: includes/class-cfwc-templates.php:964
 msgid "Canada GST & Duty"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:959
+#: includes/class-cfwc-templates.php:965
 msgid "Canadian GST and import duties"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:967
+#: includes/class-cfwc-templates.php:974
 msgid "Canada GST (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:977
+#: includes/class-cfwc-templates.php:987
 msgid "Canada Duty (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:986
+#: includes/class-cfwc-templates.php:998
 msgid "US High Tariff Countries (30%+)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:987
+#: includes/class-cfwc-templates.php:999
 msgid "Countries with 30% or higher US reciprocal tariffs"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1007
+#: includes/class-cfwc-templates.php:1019
 msgid "US Tariff (Syria)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1018
+#: includes/class-cfwc-templates.php:1030
 msgid "US Tariff (Myanmar)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1029
+#: includes/class-cfwc-templates.php:1041
 msgid "US Tariff (Laos)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1040
+#: includes/class-cfwc-templates.php:1052
 msgid "US Tariff (Iraq)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1051
+#: includes/class-cfwc-templates.php:1063
 msgid "US Tariff (Serbia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1062
+#: includes/class-cfwc-templates.php:1074
 msgid "US Tariff (Algeria)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1073
+#: includes/class-cfwc-templates.php:1085
 msgid "US Tariff (Bosnia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1084
+#: includes/class-cfwc-templates.php:1096
 msgid "US Tariff (Libya)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1092
+#: includes/class-cfwc-templates.php:1104
 msgid "US-Southeast Asia All Countries"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1093
+#: includes/class-cfwc-templates.php:1105
 msgid "All Southeast Asian countries with US reciprocal tariffs"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1124
+#: includes/class-cfwc-templates.php:1136
 msgid "US Tariff (Malaysia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1146
+#: includes/class-cfwc-templates.php:1158
 msgid "US Tariff (Philippines)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1157
+#: includes/class-cfwc-templates.php:1169
 msgid "US Tariff (Cambodia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1168
+#: includes/class-cfwc-templates.php:1180
 msgid "US Tariff (Brunei)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1176
-msgid "Australia GST"
+#: includes/class-cfwc-templates.php:1188
+msgid "Australia GST & Duty"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1177
-msgid "Australian GST (10%) on imported goods"
+#: includes/class-cfwc-templates.php:1189
+msgid "Australian GST (10%) and duty on imported goods"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1185
+#: includes/class-cfwc-templates.php:1198
 msgid "Australia GST (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1344
+#: includes/class-cfwc-templates.php:1211
+msgid "Australia Duty (Import)"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:1220
+msgid "New Zealand GST & Duty"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:1221
+msgid "New Zealand GST (15%) and duty on imported goods"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:1230
+msgid "New Zealand GST (Import)"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:1243
+msgid "New Zealand Duty (Import)"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:1252
+msgid "EU VAT & Duty"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:1253
+msgid "EU import VAT (20%) and duty for international shipments"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:1262
+msgid "EU VAT (Import)"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:1275
+msgid "EU Duty (Import)"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:1485
 #. translators: %1$d: number of rules added, %2$d: number of duplicates skipped
 msgid "Added %1$d new rules. Skipped %2$d duplicates."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1349
+#: includes/class-cfwc-templates.php:1490
 msgid "All preset rules already exist. No rules added."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1353
+#: includes/class-cfwc-templates.php:1494
 #. translators: %d: number of rules added
 msgid "%d preset rules added successfully."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1358
+#: includes/class-cfwc-templates.php:1499
 msgid "All rules replaced with preset."
 msgstr ""
 
-#: includes/class-customs-fees-woocommerce.php:105
+#: includes/class-customs-fees-woocommerce.php:110
 msgid ""
 "Customs Fees for WooCommerce requires WooCommerce to be installed and "
 "active."
 msgstr ""
 
-#: includes/class-customs-fees-woocommerce.php:163
+#: includes/class-customs-fees-woocommerce.php:201
 msgid "Cloning is forbidden."
 msgstr ""
 
-#: includes/class-customs-fees-woocommerce.php:172
+#: includes/class-customs-fees-woocommerce.php:210
 msgid "Unserializing instances of this class is forbidden."
 msgstr ""
 

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Customs Fees for WooCommerce 1.1.9\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
-"POT-Creation-Date: 2026-05-22 11:33:56+00:00\n"
+"POT-Creation-Date: 2026-05-29 10:17:08+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -14,78 +14,87 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: node-wp-i18n 1.2.8\n"
 
-#: includes/admin/class-cfwc-admin.php:65
+#: includes/admin/class-cfwc-admin.php:68
+#: includes/admin/class-cfwc-admin.php:137
 msgid "Customs Fees Warning"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:84
-#: includes/admin/class-cfwc-admin.php:111
-#: includes/admin/class-cfwc-admin.php:199 includes/class-cfwc-display.php:68
+#: includes/admin/class-cfwc-admin.php:131
+#. translators: %s: comma-separated list of affected rule names.
+msgid ""
+"These rules depend on another rule that your stacking settings remove, so "
+"their fee is calculated on an incomplete base: %s. Review the priority and "
+"stacking mode of any override or exclusive rules for the same destination."
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:193
+#: includes/admin/class-cfwc-admin.php:220
+#: includes/admin/class-cfwc-admin.php:308 includes/class-cfwc-display.php:68
 #: includes/class-cfwc-display.php:145 includes/class-cfwc-display.php:171
 #: includes/class-cfwc-display.php:225 includes/class-cfwc-display.php:384
 #: includes/class-cfwc-loader.php:279 includes/class-cfwc-settings.php:65
 msgid "Customs & Import Fees"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:126
+#: includes/admin/class-cfwc-admin.php:235
 msgid "Fees Breakdown:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:136
+#: includes/admin/class-cfwc-admin.php:245
 msgid "Total:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:139
+#: includes/admin/class-cfwc-admin.php:248
 msgid "Total Customs Fees:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:141
+#: includes/admin/class-cfwc-admin.php:250
 msgid "These fees were calculated based on the destination country and cart value."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:143
+#: includes/admin/class-cfwc-admin.php:252
 msgid "No customs fees applied to this order."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:150
+#: includes/admin/class-cfwc-admin.php:259
 msgid "Product Customs Information:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:172
-#: includes/admin/class-cfwc-admin.php:532 includes/class-cfwc-display.php:295
+#: includes/admin/class-cfwc-admin.php:281
+#: includes/admin/class-cfwc-admin.php:641 includes/class-cfwc-display.php:295
 #: includes/class-cfwc-display.php:342
 msgid "HS Code:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:179
-#: includes/admin/class-cfwc-admin.php:539 includes/class-cfwc-display.php:301
+#: includes/admin/class-cfwc-admin.php:288
+#: includes/admin/class-cfwc-admin.php:648 includes/class-cfwc-display.php:301
 #: includes/class-cfwc-display.php:348
 msgid "Origin:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:204
+#: includes/admin/class-cfwc-admin.php:313
 msgid "HS/Tariff Code"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:205
+#: includes/admin/class-cfwc-admin.php:314
 msgid "e.g., 6109.10 or 6109.10.0012"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:207
+#: includes/admin/class-cfwc-admin.php:316
 msgid ""
 "Harmonized System code for customs classification. This helps calculate "
 "accurate import duties."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:214
+#: includes/admin/class-cfwc-admin.php:323
 msgid "You can "
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:216
+#: includes/admin/class-cfwc-admin.php:325
 msgid "find HS codes here"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:243
+#: includes/admin/class-cfwc-admin.php:352
 #: includes/admin/class-cfwc-onboarding.php:281
 #: includes/admin/class-cfwc-onboarding.php:361
 #: includes/class-cfwc-export-import.php:59
@@ -96,238 +105,238 @@ msgstr ""
 msgid "Country of Origin"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:245
+#: includes/admin/class-cfwc-admin.php:354
 msgid ""
 "Select the country where this product was manufactured. This determines "
 "which customs rules apply."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:246
-#: includes/admin/class-cfwc-admin.php:250
 #: includes/admin/class-cfwc-admin.php:355
-#: includes/admin/class-cfwc-admin.php:440
+#: includes/admin/class-cfwc-admin.php:359
+#: includes/admin/class-cfwc-admin.php:464
+#: includes/admin/class-cfwc-admin.php:549
 msgid "Select a country"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:441
+#: includes/admin/class-cfwc-admin.php:550
 msgid "Please select a preset first."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:442
+#: includes/admin/class-cfwc-admin.php:551
 #: includes/admin/views/rules-section.php:417
 msgid "Import Preset Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:443
+#: includes/admin/class-cfwc-admin.php:552
 #: includes/admin/views/rules-section.php:419
 msgid "Add to Existing Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:444
+#: includes/admin/class-cfwc-admin.php:553
 msgid "Adding preset rules..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:445
+#: includes/admin/class-cfwc-admin.php:554
 msgid "Replacing all rules with preset..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:446
+#: includes/admin/class-cfwc-admin.php:555
 msgid "Click again to confirm"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:447
+#: includes/admin/class-cfwc-admin.php:556
 #: includes/admin/views/rules-section.php:424
 msgid "Replace All Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:448
+#: includes/admin/class-cfwc-admin.php:557
 msgid "No rules to delete."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:449
+#: includes/admin/class-cfwc-admin.php:558
 msgid "All rules deleted. Remember to click \"Save changes\" to persist."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:450
+#: includes/admin/class-cfwc-admin.php:559
 #: includes/admin/views/rules-section.php:523
 msgid "Delete All Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:451
+#: includes/admin/class-cfwc-admin.php:560
 msgid "Warning: This will delete all existing rules. Click again to confirm."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:452
+#: includes/admin/class-cfwc-admin.php:561
 msgid "Click to Confirm Delete"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:453
+#: includes/admin/class-cfwc-admin.php:562
 msgid "Preset applied successfully!"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:454
+#: includes/admin/class-cfwc-admin.php:563
 msgid "Remember to click \"Save changes\" to persist these rules."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:455
+#: includes/admin/class-cfwc-admin.php:564
 #: includes/class-cfwc-templates.php:1523
 msgid "Failed to apply preset."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:456
+#: includes/admin/class-cfwc-admin.php:565
 msgid "An error occurred while applying the preset."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:457
+#: includes/admin/class-cfwc-admin.php:566
 msgid "Check browser console for details."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:458
+#: includes/admin/class-cfwc-admin.php:567
 msgid "Dismiss this notice"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:459
+#: includes/admin/class-cfwc-admin.php:568
 msgid "Select country..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:460
+#: includes/admin/class-cfwc-admin.php:569
 msgid "All Origins"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:461
+#: includes/admin/class-cfwc-admin.php:570
 msgid "EU Countries"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:462
+#: includes/admin/class-cfwc-admin.php:571
 msgid "Specific Country"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:463
+#: includes/admin/class-cfwc-admin.php:572
 msgid "Fee label"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:464
+#: includes/admin/class-cfwc-admin.php:573
 msgid "Choose a country..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:465
+#: includes/admin/class-cfwc-admin.php:574
 msgid "Choose origin..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:466
+#: includes/admin/class-cfwc-admin.php:575
 msgid "Percentage"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:467
+#: includes/admin/class-cfwc-admin.php:576
 msgid "Flat"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:468
+#: includes/admin/class-cfwc-admin.php:577
 msgid "Save"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:469
+#: includes/admin/class-cfwc-admin.php:578
 msgid "Cancel"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:470
+#: includes/admin/class-cfwc-admin.php:579
 #: includes/admin/views/rules-section.php:722
 msgid "Edit"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:471
+#: includes/admin/class-cfwc-admin.php:580
 #: includes/admin/views/rules-section.php:725
 msgid "Delete"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:472
+#: includes/admin/class-cfwc-admin.php:581
 msgid "Rule saved. Remember to click \"Save changes\" to persist."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:473
+#: includes/admin/class-cfwc-admin.php:582
 msgid "Rule deleted successfully. Remember to click \"Save changes\" to persist."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:474
+#: includes/admin/class-cfwc-admin.php:583
 msgid "Click the delete button again to confirm deletion."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:475
+#: includes/admin/class-cfwc-admin.php:584
 #: includes/admin/views/rules-section.php:732
 msgid "No rules configured. Use the preset loader above or add rules manually."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:476
+#: includes/admin/class-cfwc-admin.php:585
 #: includes/class-cfwc-products-variation-support.php:64
 #: includes/class-cfwc-products-variation-support.php:87
 msgid "Not set"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:477
+#: includes/admin/class-cfwc-admin.php:586
 msgid "Valuation method"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:478
+#: includes/admin/class-cfwc-admin.php:587
 #: includes/admin/views/rules-section.php:545
 msgid "Depends on"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:479
+#: includes/admin/class-cfwc-admin.php:588
 msgid "Inherit global"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:480
+#: includes/admin/class-cfwc-admin.php:589
 #: includes/admin/views/rules-section.php:662
 msgid "Overrides global valuation"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:481
+#: includes/admin/class-cfwc-admin.php:590
 msgid "Overrides global for this rule"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:482
+#: includes/admin/class-cfwc-admin.php:591
 msgid "Select fees to include in base"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:483
+#: includes/admin/class-cfwc-admin.php:592
 msgid "Rule dependency cycle detected. Some rules may not calculate correctly."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:484
+#: includes/admin/class-cfwc-admin.php:593
 #: includes/admin/views/rules-section.php:657
 msgid "FOB"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:485
+#: includes/admin/class-cfwc-admin.php:594
 #: includes/admin/views/rules-section.php:658
 msgid "CIF"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:486
+#: includes/admin/class-cfwc-admin.php:595
 msgid "CIF + Insurance"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:487
+#: includes/admin/class-cfwc-admin.php:596
 #: includes/admin/views/rules-section.php:659
 msgid "CIF + Ins"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:488
+#: includes/admin/class-cfwc-admin.php:597
 #: includes/admin/views/rules-section.php:664
 msgid "Global"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:490
+#: includes/admin/class-cfwc-admin.php:599
 #. translators: %d: count of dependency fees included in the base
 msgid "+%d fee"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:492
+#: includes/admin/class-cfwc-admin.php:601
 #. translators: %d: count of dependency fees included in the base
 msgid "+%d fees"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:565
+#: includes/admin/class-cfwc-admin.php:674
 #: includes/admin/class-cfwc-onboarding.php:274
 #: includes/admin/class-cfwc-onboarding.php:355
 #: includes/class-cfwc-emails.php:186 includes/class-cfwc-export-import.php:58
@@ -339,7 +348,7 @@ msgstr ""
 msgid "HS Code"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:569 includes/class-cfwc-emails.php:201
+#: includes/admin/class-cfwc-admin.php:678 includes/class-cfwc-emails.php:201
 #: includes/class-cfwc-products.php:106
 msgid "Origin"
 msgstr ""
@@ -795,12 +804,12 @@ msgstr ""
 msgid "Only this rule applies"
 msgstr ""
 
-#: includes/class-cfwc-calculator.php:997
+#: includes/class-cfwc-calculator.php:1034
 #. translators: %1$s: destination country, %2$s: origin country
 msgid "Import Fees (%1$s from %2$s)"
 msgstr ""
 
-#: includes/class-cfwc-calculator.php:1005
+#: includes/class-cfwc-calculator.php:1042
 #. translators: %s: country name
 msgid "Customs & Import Fees (%s)"
 msgstr ""

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Customs Fees for WooCommerce 1.1.7\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
-"POT-Creation-Date: 2026-05-04 13:51:56+00:00\n"
+"POT-Creation-Date: 2026-05-05 09:32:59+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -14,78 +14,78 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "X-Generator: node-wp-i18n 1.2.8\n"
 
-#: includes/admin/class-cfwc-admin.php:62
+#: includes/admin/class-cfwc-admin.php:65
 msgid "Customs Fees Warning"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:81
-#: includes/admin/class-cfwc-admin.php:108
-#: includes/admin/class-cfwc-admin.php:196 includes/class-cfwc-display.php:68
+#: includes/admin/class-cfwc-admin.php:84
+#: includes/admin/class-cfwc-admin.php:111
+#: includes/admin/class-cfwc-admin.php:199 includes/class-cfwc-display.php:68
 #: includes/class-cfwc-display.php:145 includes/class-cfwc-display.php:171
 #: includes/class-cfwc-display.php:225 includes/class-cfwc-display.php:383
 #: includes/class-cfwc-loader.php:279 includes/class-cfwc-settings.php:65
 msgid "Customs & Import Fees"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:123
+#: includes/admin/class-cfwc-admin.php:126
 msgid "Fees Breakdown:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:133
+#: includes/admin/class-cfwc-admin.php:136
 msgid "Total:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:136
+#: includes/admin/class-cfwc-admin.php:139
 msgid "Total Customs Fees:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:138
+#: includes/admin/class-cfwc-admin.php:141
 msgid "These fees were calculated based on the destination country and cart value."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:140
+#: includes/admin/class-cfwc-admin.php:143
 msgid "No customs fees applied to this order."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:147
+#: includes/admin/class-cfwc-admin.php:150
 msgid "Product Customs Information:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:169
-#: includes/admin/class-cfwc-admin.php:529 includes/class-cfwc-display.php:295
+#: includes/admin/class-cfwc-admin.php:172
+#: includes/admin/class-cfwc-admin.php:532 includes/class-cfwc-display.php:295
 #: includes/class-cfwc-display.php:342
 msgid "HS Code:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:176
-#: includes/admin/class-cfwc-admin.php:536 includes/class-cfwc-display.php:301
+#: includes/admin/class-cfwc-admin.php:179
+#: includes/admin/class-cfwc-admin.php:539 includes/class-cfwc-display.php:301
 #: includes/class-cfwc-display.php:348
 msgid "Origin:"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:201
+#: includes/admin/class-cfwc-admin.php:204
 msgid "HS/Tariff Code"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:202
+#: includes/admin/class-cfwc-admin.php:205
 msgid "e.g., 6109.10 or 6109.10.0012"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:204
+#: includes/admin/class-cfwc-admin.php:207
 msgid ""
 "Harmonized System code for customs classification. This helps calculate "
 "accurate import duties."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:211
+#: includes/admin/class-cfwc-admin.php:214
 msgid "You can "
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:213
+#: includes/admin/class-cfwc-admin.php:216
 msgid "find HS codes here"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:240
+#: includes/admin/class-cfwc-admin.php:243
 #: includes/admin/class-cfwc-onboarding.php:281
 #: includes/admin/class-cfwc-onboarding.php:361
 #: includes/class-cfwc-export-import.php:59
@@ -96,238 +96,238 @@ msgstr ""
 msgid "Country of Origin"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:242
+#: includes/admin/class-cfwc-admin.php:245
 msgid ""
 "Select the country where this product was manufactured. This determines "
 "which customs rules apply."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:243
-#: includes/admin/class-cfwc-admin.php:247
-#: includes/admin/class-cfwc-admin.php:352
-#: includes/admin/class-cfwc-admin.php:437
+#: includes/admin/class-cfwc-admin.php:246
+#: includes/admin/class-cfwc-admin.php:250
+#: includes/admin/class-cfwc-admin.php:355
+#: includes/admin/class-cfwc-admin.php:440
 msgid "Select a country"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:438
+#: includes/admin/class-cfwc-admin.php:441
 msgid "Please select a preset first."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:439
+#: includes/admin/class-cfwc-admin.php:442
 #: includes/admin/views/rules-section.php:583
 msgid "Import Preset Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:440
+#: includes/admin/class-cfwc-admin.php:443
 #: includes/admin/views/rules-section.php:585
 msgid "Add to Existing Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:441
+#: includes/admin/class-cfwc-admin.php:444
 msgid "Adding preset rules..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:442
+#: includes/admin/class-cfwc-admin.php:445
 msgid "Replacing all rules with preset..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:443
+#: includes/admin/class-cfwc-admin.php:446
 msgid "Click again to confirm"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:444
+#: includes/admin/class-cfwc-admin.php:447
 #: includes/admin/views/rules-section.php:590
 msgid "Replace All Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:445
+#: includes/admin/class-cfwc-admin.php:448
 msgid "No rules to delete."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:446
+#: includes/admin/class-cfwc-admin.php:449
 msgid "All rules deleted. Remember to click \"Save changes\" to persist."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:447
+#: includes/admin/class-cfwc-admin.php:450
 #: includes/admin/views/rules-section.php:689
 msgid "Delete All Rules"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:448
+#: includes/admin/class-cfwc-admin.php:451
 msgid "Warning: This will delete all existing rules. Click again to confirm."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:449
+#: includes/admin/class-cfwc-admin.php:452
 msgid "Click to Confirm Delete"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:450
+#: includes/admin/class-cfwc-admin.php:453
 msgid "Preset applied successfully!"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:451
+#: includes/admin/class-cfwc-admin.php:454
 msgid "Remember to click \"Save changes\" to persist these rules."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:452
-#: includes/class-cfwc-templates.php:1513
+#: includes/admin/class-cfwc-admin.php:455
+#: includes/class-cfwc-templates.php:1518
 msgid "Failed to apply preset."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:453
+#: includes/admin/class-cfwc-admin.php:456
 msgid "An error occurred while applying the preset."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:454
+#: includes/admin/class-cfwc-admin.php:457
 msgid "Check browser console for details."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:455
+#: includes/admin/class-cfwc-admin.php:458
 msgid "Dismiss this notice"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:456
+#: includes/admin/class-cfwc-admin.php:459
 msgid "Select country..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:457
+#: includes/admin/class-cfwc-admin.php:460
 msgid "All Origins"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:458
+#: includes/admin/class-cfwc-admin.php:461
 msgid "EU Countries"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:459
+#: includes/admin/class-cfwc-admin.php:462
 msgid "Specific Country"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:460
+#: includes/admin/class-cfwc-admin.php:463
 msgid "Fee label"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:461
+#: includes/admin/class-cfwc-admin.php:464
 msgid "Choose a country..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:462
+#: includes/admin/class-cfwc-admin.php:465
 msgid "Choose origin..."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:463
+#: includes/admin/class-cfwc-admin.php:466
 msgid "Percentage"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:464
+#: includes/admin/class-cfwc-admin.php:467
 msgid "Flat"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:465
+#: includes/admin/class-cfwc-admin.php:468
 msgid "Save"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:466
+#: includes/admin/class-cfwc-admin.php:469
 msgid "Cancel"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:467
+#: includes/admin/class-cfwc-admin.php:470
 #: includes/admin/views/rules-section.php:896
 msgid "Edit"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:468
+#: includes/admin/class-cfwc-admin.php:471
 #: includes/admin/views/rules-section.php:899
 msgid "Delete"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:469
+#: includes/admin/class-cfwc-admin.php:472
 msgid "Rule saved. Remember to click \"Save changes\" to persist."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:470
+#: includes/admin/class-cfwc-admin.php:473
 msgid "Rule deleted successfully. Remember to click \"Save changes\" to persist."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:471
+#: includes/admin/class-cfwc-admin.php:474
 msgid "Click the delete button again to confirm deletion."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:472
+#: includes/admin/class-cfwc-admin.php:475
 #: includes/admin/views/rules-section.php:906
 msgid "No rules configured. Use the preset loader above or add rules manually."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:473
+#: includes/admin/class-cfwc-admin.php:476
 #: includes/class-cfwc-products-variation-support.php:64
 #: includes/class-cfwc-products-variation-support.php:87
 msgid "Not set"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:474
+#: includes/admin/class-cfwc-admin.php:477
 msgid "Valuation method"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:475
+#: includes/admin/class-cfwc-admin.php:478
 #: includes/admin/views/rules-section.php:711
 msgid "Depends on"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:476
+#: includes/admin/class-cfwc-admin.php:479
 msgid "Inherit global"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:477
+#: includes/admin/class-cfwc-admin.php:480
 #: includes/admin/views/rules-section.php:829
 msgid "Overrides global valuation"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:478
+#: includes/admin/class-cfwc-admin.php:481
 msgid "Overrides global for this rule"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:479
+#: includes/admin/class-cfwc-admin.php:482
 msgid "Select fees to include in base"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:480
+#: includes/admin/class-cfwc-admin.php:483
 msgid "Rule dependency cycle detected. Some rules may not calculate correctly."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:481
+#: includes/admin/class-cfwc-admin.php:484
 #: includes/admin/views/rules-section.php:824
 msgid "FOB"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:482
+#: includes/admin/class-cfwc-admin.php:485
 #: includes/admin/views/rules-section.php:825
 msgid "CIF"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:483
+#: includes/admin/class-cfwc-admin.php:486
 msgid "CIF + Insurance"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:484
+#: includes/admin/class-cfwc-admin.php:487
 #: includes/admin/views/rules-section.php:826
 msgid "CIF + Ins"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:485
+#: includes/admin/class-cfwc-admin.php:488
 #: includes/admin/views/rules-section.php:831
 msgid "Global"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:487
+#: includes/admin/class-cfwc-admin.php:490
 #. translators: %d: count of dependency fees included in the base
 msgid "+%d fee"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:489
+#: includes/admin/class-cfwc-admin.php:492
 #. translators: %d: count of dependency fees included in the base
 msgid "+%d fees"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:562
+#: includes/admin/class-cfwc-admin.php:565
 #: includes/admin/class-cfwc-onboarding.php:274
 #: includes/admin/class-cfwc-onboarding.php:355
 #: includes/class-cfwc-emails.php:186 includes/class-cfwc-export-import.php:58
@@ -339,62 +339,62 @@ msgstr ""
 msgid "HS Code"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:566 includes/class-cfwc-emails.php:201
+#: includes/admin/class-cfwc-admin.php:569 includes/class-cfwc-emails.php:201
 #: includes/class-cfwc-products.php:106
 msgid "Origin"
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:128
+#: includes/admin/class-cfwc-ajax.php:133
 msgid "Rule saved successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:154
+#: includes/admin/class-cfwc-ajax.php:159
 msgid "Invalid rule ID."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:194
+#: includes/admin/class-cfwc-ajax.php:230
 msgid "Rule deleted successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:200
+#: includes/admin/class-cfwc-ajax.php:236
 msgid "Rule not found."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:225
+#: includes/admin/class-cfwc-ajax.php:261
 msgid "Invalid order data."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:249
+#: includes/admin/class-cfwc-ajax.php:290
 msgid "Rules reordered successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:302
+#: includes/admin/class-cfwc-ajax.php:343
 msgid "Export ready for download."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:327
+#: includes/admin/class-cfwc-ajax.php:368
 msgid "No CSV content provided."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:419
+#: includes/admin/class-cfwc-ajax.php:460
 msgid "No valid rules found in CSV."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:440
+#: includes/admin/class-cfwc-ajax.php:486
 #. translators: %d: Number of rules imported
 msgid "%d rules imported successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:467
+#: includes/admin/class-cfwc-ajax.php:513
 msgid "Invalid test parameters."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:550
-#: includes/admin/class-cfwc-ajax.php:575
+#: includes/admin/class-cfwc-ajax.php:596
+#: includes/admin/class-cfwc-ajax.php:621
 msgid "Customs Fee"
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:589
+#: includes/admin/class-cfwc-ajax.php:635
 msgid "Calculation complete."
 msgstr ""
 
@@ -794,12 +794,12 @@ msgstr ""
 msgid "Only this rule applies"
 msgstr ""
 
-#: includes/class-cfwc-calculator.php:920
+#: includes/class-cfwc-calculator.php:977
 #. translators: %1$s: destination country, %2$s: origin country
 msgid "Import Fees (%1$s from %2$s)"
 msgstr ""
 
-#: includes/class-cfwc-calculator.php:928
+#: includes/class-cfwc-calculator.php:985
 #. translators: %s: country name
 msgid "Customs & Import Fees (%s)"
 msgstr ""
@@ -810,7 +810,7 @@ msgid "Customs & Import Information"
 msgstr ""
 
 #: includes/class-cfwc-display.php:239 includes/class-cfwc-display.php:250
-#: includes/class-cfwc-settings.php:365
+#: includes/class-cfwc-settings.php:370
 msgid "Estimated import duties and taxes based on destination country."
 msgstr ""
 
@@ -948,7 +948,7 @@ msgstr ""
 msgid "Customs & Import Fees Settings"
 msgstr ""
 
-#: includes/class-cfwc-settings.php:351
+#: includes/class-cfwc-settings.php:356
 msgid "All Countries"
 msgstr ""
 
@@ -1505,21 +1505,21 @@ msgstr ""
 msgid "EU Duty (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1485
+#: includes/class-cfwc-templates.php:1490
 #. translators: %1$d: number of rules added, %2$d: number of duplicates skipped
 msgid "Added %1$d new rules. Skipped %2$d duplicates."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1490
+#: includes/class-cfwc-templates.php:1495
 msgid "All preset rules already exist. No rules added."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1494
+#: includes/class-cfwc-templates.php:1499
 #. translators: %d: number of rules added
 msgid "%d preset rules added successfully."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1499
+#: includes/class-cfwc-templates.php:1504
 msgid "All rules replaced with preset."
 msgstr ""
 

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Customs Fees for WooCommerce 1.1.9\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
-"POT-Creation-Date: 2026-05-21 17:12:45+00:00\n"
+"POT-Creation-Date: 2026-05-22 11:33:56+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -170,7 +170,7 @@ msgid "Remember to click \"Save changes\" to persist these rules."
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:455
-#: includes/class-cfwc-templates.php:1518
+#: includes/class-cfwc-templates.php:1523
 msgid "Failed to apply preset."
 msgstr ""
 
@@ -1506,21 +1506,21 @@ msgstr ""
 msgid "EU Duty (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1490
+#: includes/class-cfwc-templates.php:1495
 #. translators: %1$d: number of rules added, %2$d: number of duplicates skipped
 msgid "Added %1$d new rules. Skipped %2$d duplicates."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1495
+#: includes/class-cfwc-templates.php:1500
 msgid "All preset rules already exist. No rules added."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1499
+#: includes/class-cfwc-templates.php:1504
 #. translators: %d: number of rules added
 msgid "%d preset rules added successfully."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1504
+#: includes/class-cfwc-templates.php:1509
 msgid "All rules replaced with preset."
 msgstr ""
 

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Customs Fees for WooCommerce 1.1.7\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
-"POT-Creation-Date: 2026-05-05 09:32:59+00:00\n"
+"POT-Creation-Date: 2026-05-05 09:51:21+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -344,57 +344,58 @@ msgstr ""
 msgid "Origin"
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:133
+#: includes/admin/class-cfwc-ajax.php:139
 msgid "Rule saved successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:159
+#: includes/admin/class-cfwc-ajax.php:165
 msgid "Invalid rule ID."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:230
+#: includes/admin/class-cfwc-ajax.php:236
 msgid "Rule deleted successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:236
+#: includes/admin/class-cfwc-ajax.php:242
 msgid "Rule not found."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:261
+#: includes/admin/class-cfwc-ajax.php:267
+#: includes/admin/class-cfwc-ajax.php:289
 msgid "Invalid order data."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:290
+#: includes/admin/class-cfwc-ajax.php:307
 msgid "Rules reordered successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:343
+#: includes/admin/class-cfwc-ajax.php:360
 msgid "Export ready for download."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:368
+#: includes/admin/class-cfwc-ajax.php:385
 msgid "No CSV content provided."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:460
+#: includes/admin/class-cfwc-ajax.php:477
 msgid "No valid rules found in CSV."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:486
+#: includes/admin/class-cfwc-ajax.php:503
 #. translators: %d: Number of rules imported
 msgid "%d rules imported successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:513
+#: includes/admin/class-cfwc-ajax.php:530
 msgid "Invalid test parameters."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:596
-#: includes/admin/class-cfwc-ajax.php:621
+#: includes/admin/class-cfwc-ajax.php:613
+#: includes/admin/class-cfwc-ajax.php:638
 msgid "Customs Fee"
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:635
+#: includes/admin/class-cfwc-ajax.php:652
 msgid "Calculation complete."
 msgstr ""
 
@@ -1529,11 +1530,11 @@ msgid ""
 "active."
 msgstr ""
 
-#: includes/class-customs-fees-woocommerce.php:201
+#: includes/class-customs-fees-woocommerce.php:207
 msgid "Cloning is forbidden."
 msgstr ""
 
-#: includes/class-customs-fees-woocommerce.php:210
+#: includes/class-customs-fees-woocommerce.php:216
 msgid "Unserializing instances of this class is forbidden."
 msgstr ""
 

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Customs Fees for WooCommerce 1.1.7\n"
+"Project-Id-Version: Customs Fees for WooCommerce 1.1.9\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
-"POT-Creation-Date: 2026-05-05 10:11:04+00:00\n"
+"POT-Creation-Date: 2026-05-21 17:12:45+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -795,12 +795,12 @@ msgstr ""
 msgid "Only this rule applies"
 msgstr ""
 
-#: includes/class-cfwc-calculator.php:977
+#: includes/class-cfwc-calculator.php:997
 #. translators: %1$s: destination country, %2$s: origin country
 msgid "Import Fees (%1$s from %2$s)"
 msgstr ""
 
-#: includes/class-cfwc-calculator.php:985
+#: includes/class-cfwc-calculator.php:1005
 #. translators: %s: country name
 msgid "Customs & Import Fees (%s)"
 msgstr ""

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Customs Fees for WooCommerce 1.1.7\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
-"POT-Creation-Date: 2026-05-05 09:51:21+00:00\n"
+"POT-Creation-Date: 2026-05-05 10:11:04+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -22,7 +22,7 @@ msgstr ""
 #: includes/admin/class-cfwc-admin.php:111
 #: includes/admin/class-cfwc-admin.php:199 includes/class-cfwc-display.php:68
 #: includes/class-cfwc-display.php:145 includes/class-cfwc-display.php:171
-#: includes/class-cfwc-display.php:225 includes/class-cfwc-display.php:383
+#: includes/class-cfwc-display.php:225 includes/class-cfwc-display.php:384
 #: includes/class-cfwc-loader.php:279 includes/class-cfwc-settings.php:65
 msgid "Customs & Import Fees"
 msgstr ""
@@ -114,12 +114,12 @@ msgid "Please select a preset first."
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:442
-#: includes/admin/views/rules-section.php:583
+#: includes/admin/views/rules-section.php:417
 msgid "Import Preset Rules"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:443
-#: includes/admin/views/rules-section.php:585
+#: includes/admin/views/rules-section.php:419
 msgid "Add to Existing Rules"
 msgstr ""
 
@@ -136,7 +136,7 @@ msgid "Click again to confirm"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:447
-#: includes/admin/views/rules-section.php:590
+#: includes/admin/views/rules-section.php:424
 msgid "Replace All Rules"
 msgstr ""
 
@@ -149,7 +149,7 @@ msgid "All rules deleted. Remember to click \"Save changes\" to persist."
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:450
-#: includes/admin/views/rules-section.php:689
+#: includes/admin/views/rules-section.php:523
 msgid "Delete All Rules"
 msgstr ""
 
@@ -231,12 +231,12 @@ msgid "Cancel"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:470
-#: includes/admin/views/rules-section.php:896
+#: includes/admin/views/rules-section.php:722
 msgid "Edit"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:471
-#: includes/admin/views/rules-section.php:899
+#: includes/admin/views/rules-section.php:725
 msgid "Delete"
 msgstr ""
 
@@ -253,7 +253,7 @@ msgid "Click the delete button again to confirm deletion."
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:475
-#: includes/admin/views/rules-section.php:906
+#: includes/admin/views/rules-section.php:732
 msgid "No rules configured. Use the preset loader above or add rules manually."
 msgstr ""
 
@@ -268,7 +268,7 @@ msgid "Valuation method"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:478
-#: includes/admin/views/rules-section.php:711
+#: includes/admin/views/rules-section.php:545
 msgid "Depends on"
 msgstr ""
 
@@ -277,7 +277,7 @@ msgid "Inherit global"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:480
-#: includes/admin/views/rules-section.php:829
+#: includes/admin/views/rules-section.php:662
 msgid "Overrides global valuation"
 msgstr ""
 
@@ -294,12 +294,12 @@ msgid "Rule dependency cycle detected. Some rules may not calculate correctly."
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:484
-#: includes/admin/views/rules-section.php:824
+#: includes/admin/views/rules-section.php:657
 msgid "FOB"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:485
-#: includes/admin/views/rules-section.php:825
+#: includes/admin/views/rules-section.php:658
 msgid "CIF"
 msgstr ""
 
@@ -308,12 +308,12 @@ msgid "CIF + Insurance"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:487
-#: includes/admin/views/rules-section.php:826
+#: includes/admin/views/rules-section.php:659
 msgid "CIF + Ins"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:488
-#: includes/admin/views/rules-section.php:831
+#: includes/admin/views/rules-section.php:664
 msgid "Global"
 msgstr ""
 
@@ -627,7 +627,7 @@ msgid "Rule stacking modes"
 msgstr ""
 
 #: includes/admin/views/rules-section.php:249
-#: includes/admin/views/rules-section.php:867
+#: includes/admin/views/rules-section.php:700
 msgid "Stack"
 msgstr ""
 
@@ -636,7 +636,7 @@ msgid "Adds with other matching rules."
 msgstr ""
 
 #: includes/admin/views/rules-section.php:253
-#: includes/admin/views/rules-section.php:868
+#: includes/admin/views/rules-section.php:701
 msgid "Override"
 msgstr ""
 
@@ -645,7 +645,7 @@ msgid "Replaces lower priority rules."
 msgstr ""
 
 #: includes/admin/views/rules-section.php:257
-#: includes/admin/views/rules-section.php:869
+#: includes/admin/views/rules-section.php:702
 msgid "Exclusive"
 msgstr ""
 
@@ -657,36 +657,36 @@ msgstr ""
 msgid "Got it"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:565
+#: includes/admin/views/rules-section.php:399
 msgid "Quick Start with Presets"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:566
+#: includes/admin/views/rules-section.php:400
 msgid "Load presets to quickly configure common import scenarios:"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:569
+#: includes/admin/views/rules-section.php:403
 msgid "-- Select a preset --"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:628
+#: includes/admin/views/rules-section.php:462
 msgid "⚠️ Rule Stacking Detected"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:632
+#: includes/admin/views/rules-section.php:466
 msgid ""
 "You have both general (Any → Country) and specific (Country → Country) "
 "rules with \"Add\" stacking mode. These will combine unless you set them to "
 "\"Exclusive\" or \"Override\" mode."
 msgstr ""
 
-#: includes/admin/views/rules-section.php:633
+#: includes/admin/views/rules-section.php:467
 msgid ""
 "Example: A general \"Any → US 10%\" rule will add to \"China → US 25%\" if "
 "both are in \"Add\" mode."
 msgstr ""
 
-#: includes/admin/views/rules-section.php:642
+#: includes/admin/views/rules-section.php:476
 #. translators: %s: list of countries
 msgid ""
 "You have multiple rules with \"Add\" stacking mode for %s. These fees will "
@@ -694,104 +694,104 @@ msgid ""
 "only the highest priority rule to apply."
 msgstr ""
 
-#: includes/admin/views/rules-section.php:670
+#: includes/admin/views/rules-section.php:504
 msgid "Dismiss this notice."
 msgstr ""
 
-#: includes/admin/views/rules-section.php:684
+#: includes/admin/views/rules-section.php:518
 msgid "All Rules"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:686
+#: includes/admin/views/rules-section.php:520
 msgid "Add New Rule"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:692
+#: includes/admin/views/rules-section.php:526
 msgid ""
 "Configure customs fee rules based on destination countries, product "
 "origins, categories, and HS codes."
 msgstr ""
 
-#: includes/admin/views/rules-section.php:696
+#: includes/admin/views/rules-section.php:530
 msgid "Need help getting started?"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:705
+#: includes/admin/views/rules-section.php:539
 msgid "Label"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:706
+#: includes/admin/views/rules-section.php:540
 msgid "Countries"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:707
+#: includes/admin/views/rules-section.php:541
 msgid "Products"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:708
+#: includes/admin/views/rules-section.php:542
 msgid "Type"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:709
+#: includes/admin/views/rules-section.php:543
 msgid "Rate"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:710
+#: includes/admin/views/rules-section.php:544
 msgid "Valuation"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:712
+#: includes/admin/views/rules-section.php:546
 msgid "Stacking"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:713
+#: includes/admin/views/rules-section.php:547
 msgid "Actions"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:729
+#: includes/admin/views/rules-section.php:563
 msgid "Higher priority rules are checked first (0-100)"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:746
+#: includes/admin/views/rules-section.php:580
 msgid "All → All"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:750
+#: includes/admin/views/rules-section.php:584
 #. translators: %s: destination country name
 msgid "Any → %s"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:754
+#: includes/admin/views/rules-section.php:588
 #. translators: %s: origin country name
 msgid "%s → Any"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:769
-#: includes/admin/views/rules-section.php:806
+#: includes/admin/views/rules-section.php:603
+#: includes/admin/views/rules-section.php:639
 msgid "All Products"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:784
+#: includes/admin/views/rules-section.php:618
 #. translators: %d: number of additional categories
 msgid "+%d more"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:852
+#: includes/admin/views/rules-section.php:685
 #. translators: %s: count of dependency fees included in the base
 msgid "+%s fee"
 msgid_plural "+%s fees"
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/admin/views/rules-section.php:879
+#: includes/admin/views/rules-section.php:706
 msgid "Adds with other matching rules"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:880
+#: includes/admin/views/rules-section.php:707
 msgid "Replaces lower priority rules"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:881
+#: includes/admin/views/rules-section.php:708
 msgid "Only this rule applies"
 msgstr ""
 
@@ -806,7 +806,7 @@ msgid "Customs & Import Fees (%s)"
 msgstr ""
 
 #: includes/class-cfwc-display.php:237 includes/class-cfwc-display.php:249
-#: includes/class-cfwc-display.php:393 includes/class-cfwc-emails.php:269
+#: includes/class-cfwc-display.php:394 includes/class-cfwc-emails.php:269
 msgid "Customs & Import Information"
 msgstr ""
 
@@ -826,7 +826,7 @@ msgid ""
 "depending on customs regulations and carrier handling charges."
 msgstr ""
 
-#: includes/class-cfwc-display.php:394
+#: includes/class-cfwc-display.php:395
 msgid ""
 "The customs and import fees shown above are estimated based on current "
 "rates. Actual fees may vary depending on customs regulations and carrier "

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -5,7 +5,7 @@ msgstr ""
 "Project-Id-Version: Customs Fees for WooCommerce 1.1.7\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
-"POT-Creation-Date: 2026-04-27 15:42:21+00:00\n"
+"POT-Creation-Date: 2026-05-04 13:51:56+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -52,13 +52,13 @@ msgid "Product Customs Information:"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:169
-#: includes/admin/class-cfwc-admin.php:519 includes/class-cfwc-display.php:295
+#: includes/admin/class-cfwc-admin.php:529 includes/class-cfwc-display.php:295
 #: includes/class-cfwc-display.php:342
 msgid "HS Code:"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:176
-#: includes/admin/class-cfwc-admin.php:526 includes/class-cfwc-display.php:301
+#: includes/admin/class-cfwc-admin.php:536 includes/class-cfwc-display.php:301
 #: includes/class-cfwc-display.php:348
 msgid "Origin:"
 msgstr ""
@@ -231,12 +231,12 @@ msgid "Cancel"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:467
-#: includes/admin/views/rules-section.php:891
+#: includes/admin/views/rules-section.php:896
 msgid "Edit"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:468
-#: includes/admin/views/rules-section.php:894
+#: includes/admin/views/rules-section.php:899
 msgid "Delete"
 msgstr ""
 
@@ -253,7 +253,7 @@ msgid "Click the delete button again to confirm deletion."
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:472
-#: includes/admin/views/rules-section.php:901
+#: includes/admin/views/rules-section.php:906
 msgid "No rules configured. Use the preset loader above or add rules manually."
 msgstr ""
 
@@ -282,14 +282,52 @@ msgid "Overrides global valuation"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:478
-msgid "Select fees to include in base"
+msgid "Overrides global for this rule"
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:479
+msgid "Select fees to include in base"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:480
 msgid "Rule dependency cycle detected. Some rules may not calculate correctly."
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:552
+#: includes/admin/class-cfwc-admin.php:481
+#: includes/admin/views/rules-section.php:824
+msgid "FOB"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:482
+#: includes/admin/views/rules-section.php:825
+msgid "CIF"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:483
+msgid "CIF + Insurance"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:484
+#: includes/admin/views/rules-section.php:826
+msgid "CIF + Ins"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:485
+#: includes/admin/views/rules-section.php:831
+msgid "Global"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:487
+#. translators: %d: count of dependency fees included in the base
+msgid "+%d fee"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:489
+#. translators: %d: count of dependency fees included in the base
+msgid "+%d fees"
+msgstr ""
+
+#: includes/admin/class-cfwc-admin.php:562
 #: includes/admin/class-cfwc-onboarding.php:274
 #: includes/admin/class-cfwc-onboarding.php:355
 #: includes/class-cfwc-emails.php:186 includes/class-cfwc-export-import.php:58
@@ -301,7 +339,7 @@ msgstr ""
 msgid "HS Code"
 msgstr ""
 
-#: includes/admin/class-cfwc-admin.php:556 includes/class-cfwc-emails.php:201
+#: includes/admin/class-cfwc-admin.php:566 includes/class-cfwc-emails.php:201
 #: includes/class-cfwc-products.php:106
 msgid "Origin"
 msgstr ""
@@ -310,53 +348,53 @@ msgstr ""
 msgid "Rule saved successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:155
+#: includes/admin/class-cfwc-ajax.php:154
 msgid "Invalid rule ID."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:197
+#: includes/admin/class-cfwc-ajax.php:194
 msgid "Rule deleted successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:203
+#: includes/admin/class-cfwc-ajax.php:200
 msgid "Rule not found."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:228
+#: includes/admin/class-cfwc-ajax.php:225
 msgid "Invalid order data."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:252
+#: includes/admin/class-cfwc-ajax.php:249
 msgid "Rules reordered successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:305
+#: includes/admin/class-cfwc-ajax.php:302
 msgid "Export ready for download."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:330
+#: includes/admin/class-cfwc-ajax.php:327
 msgid "No CSV content provided."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:412
+#: includes/admin/class-cfwc-ajax.php:419
 msgid "No valid rules found in CSV."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:433
+#: includes/admin/class-cfwc-ajax.php:440
 #. translators: %d: Number of rules imported
 msgid "%d rules imported successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:460
+#: includes/admin/class-cfwc-ajax.php:467
 msgid "Invalid test parameters."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:543
-#: includes/admin/class-cfwc-ajax.php:568
+#: includes/admin/class-cfwc-ajax.php:550
+#: includes/admin/class-cfwc-ajax.php:575
 msgid "Customs Fee"
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:582
+#: includes/admin/class-cfwc-ajax.php:589
 msgid "Calculation complete."
 msgstr ""
 
@@ -588,7 +626,7 @@ msgid "Rule stacking modes"
 msgstr ""
 
 #: includes/admin/views/rules-section.php:249
-#: includes/admin/views/rules-section.php:862
+#: includes/admin/views/rules-section.php:867
 msgid "Stack"
 msgstr ""
 
@@ -597,7 +635,7 @@ msgid "Adds with other matching rules."
 msgstr ""
 
 #: includes/admin/views/rules-section.php:253
-#: includes/admin/views/rules-section.php:863
+#: includes/admin/views/rules-section.php:868
 msgid "Override"
 msgstr ""
 
@@ -606,7 +644,7 @@ msgid "Replaces lower priority rules."
 msgstr ""
 
 #: includes/admin/views/rules-section.php:257
-#: includes/admin/views/rules-section.php:864
+#: includes/admin/views/rules-section.php:869
 msgid "Exclusive"
 msgstr ""
 
@@ -737,31 +775,22 @@ msgstr ""
 msgid "+%d more"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:824
-msgid "FOB"
-msgstr ""
+#: includes/admin/views/rules-section.php:852
+#. translators: %s: count of dependency fees included in the base
+msgid "+%s fee"
+msgid_plural "+%s fees"
+msgstr[0] ""
+msgstr[1] ""
 
-#: includes/admin/views/rules-section.php:825
-msgid "CIF"
-msgstr ""
-
-#: includes/admin/views/rules-section.php:826
-msgid "CIF + Ins"
-msgstr ""
-
-#: includes/admin/views/rules-section.php:831
-msgid "Global"
-msgstr ""
-
-#: includes/admin/views/rules-section.php:874
+#: includes/admin/views/rules-section.php:879
 msgid "Adds with other matching rules"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:875
+#: includes/admin/views/rules-section.php:880
 msgid "Replaces lower priority rules"
 msgstr ""
 
-#: includes/admin/views/rules-section.php:876
+#: includes/admin/views/rules-section.php:881
 msgid "Only this rule applies"
 msgstr ""
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	verbose="true">
+	<testsuites>
+		<testsuite name="Customs Fees Unit Tests">
+			<directory suffix="Test.php">./tests/Unit</directory>
+		</testsuite>
+	</testsuites>
+	<coverage>
+		<include>
+			<directory suffix=".php">./includes</directory>
+		</include>
+	</coverage>
+</phpunit>

--- a/readme.txt
+++ b/readme.txt
@@ -192,16 +192,18 @@ Yes, through:
 
 == Changelog ==
 
-= 1.1.7 - 2026-xx-xx =
+= 1.2.0 - 2026-xx-xx =
 * Add - Per-rule valuation method override (FOB, CIF, CIF + Insurance) with inheritance from global setting.
 * Add - Compound base support via base_includes: rules can include other rules' computed fees in their customs value.
 * Add - Round-based dependency resolution with cycle detection for base_includes.
 * Add - Admin UI columns for Valuation and Depends On in the rules table.
 * Update - Canada, Australia, New Zealand, UK, and EU presets use correct duty vs. import tax valuation bases.
 * Update - CSV export/import preserves rule_id, valuation_method, base_includes, and all advanced rule fields.
+
+= 1.1.7 - 2026-04-13 =
 * Tweak - WooCommerce 10.7 Compatibility.
 
-= 1.1.6 - 2026-xx-xx =
+= 1.1.6 - 2026-03-31 =
 * Tweak - WooCommerce 10.6 Compatibility.
 
 = 1.1.5 - 2026-02-04 =

--- a/readme.txt
+++ b/readme.txt
@@ -193,12 +193,8 @@ Yes, through:
 == Changelog ==
 
 = 1.2.0 - 2026-xx-xx =
-* Add - Per-rule valuation method override (FOB, CIF, CIF + Insurance) with inheritance from global setting.
-* Add - Compound base support via base_includes: rules can include other rules' computed fees in their customs value.
-* Add - Round-based dependency resolution with cycle detection for base_includes.
-* Add - Admin UI columns for Valuation and Depends On in the rules table.
-* Update - Canada, Australia, New Zealand, UK, and EU presets use correct duty vs. import tax valuation bases.
-* Update - CSV export/import preserves rule_id, valuation_method, base_includes, and all advanced rule fields.
+* Add - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
+* Update - Built-in presets for Canada, Australia, New Zealand, UK, and EU now use correct duty vs. import tax valuation bases.
 
 = 1.1.7 - 2026-04-13 =
 * Tweak - WooCommerce 10.7 Compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -193,6 +193,12 @@ Yes, through:
 == Changelog ==
 
 = 1.1.7 - 2026-xx-xx =
+* Add - Per-rule valuation method override (FOB, CIF, CIF + Insurance) with inheritance from global setting.
+* Add - Compound base support via base_includes: rules can include other rules' computed fees in their customs value.
+* Add - Round-based dependency resolution with cycle detection for base_includes.
+* Add - Admin UI columns for Valuation and Depends On in the rules table.
+* Update - Canada, Australia, New Zealand, UK, and EU presets use correct duty vs. import tax valuation bases.
+* Update - CSV export/import preserves rule_id, valuation_method, base_includes, and all advanced rule fields.
 * Tweak - WooCommerce 10.7 Compatibility.
 
 = 1.1.6 - 2026-xx-xx =

--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,7 @@ Yes, through:
 2026-xx-xx - version 1.2.0
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
 * Update - Built-in presets for Canada, Australia, New Zealand, UK, and EU now use correct duty vs. import tax valuation bases.
+* Dev    - `cfwc_customs_value` filter now passes the matching rule as a 5th argument; existing 4-argument callbacks remain backwards-compatible.
 * Tweak  - WooCommerce 10.8 Compatibility.
 
 = 1.1.7 - 2026-04-13 =

--- a/readme.txt
+++ b/readme.txt
@@ -192,7 +192,7 @@ Yes, through:
 
 == Changelog ==
 
-2026-xx-xx - version 1.2.0
+= 1.2.0 - 2026-xx-xx =
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
 * Update - Built-in presets for Canada, Australia, New Zealand, UK, and EU now use correct duty vs. import tax valuation bases.
 * Dev    - `cfwc_customs_value` filter now passes the matching rule as a 5th argument; existing 4-argument callbacks remain backwards-compatible.

--- a/tests/Unit/Broken_Dependency_Detection_Test.php
+++ b/tests/Unit/Broken_Dependency_Detection_Test.php
@@ -1,0 +1,212 @@
+<?php
+/**
+ * Unit tests for save-time detection of stacking-broken base_includes dependencies.
+ *
+ * Covers case (a) of the stacking/compounding interaction: a general rule
+ * survives stacking but a rule it depends on is removed by a higher-priority
+ * override/exclusive rule for the same destination, so its fee compounds on an
+ * incomplete base. CFWC_Rule_Matcher::detect_broken_dependencies() derives this
+ * from the saved rules so the settings page can warn without a cart calculation.
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\CustomsFees\Tests\Unit;
+
+/**
+ * @covers \CFWC_Rule_Matcher::detect_broken_dependencies
+ */
+class Broken_Dependency_Detection_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Build a general CA rule.
+	 *
+	 * @param string $id         Rule ID.
+	 * @param float  $rate       Percentage rate.
+	 * @param string $label      Display label.
+	 * @param string $stacking   Stacking mode (add|override|exclusive).
+	 * @param int    $priority   Priority (higher sorts first).
+	 * @param array  $deps       base_includes dependency ids.
+	 * @param string $match_type Match type (all|category|hs_code|combined).
+	 * @param string $from       Origin restriction (empty = any origin).
+	 * @return array Rule data.
+	 */
+	private function rule( string $id, float $rate, string $label, string $stacking = 'add', int $priority = 0, array $deps = array(), string $match_type = 'all', string $from = '' ): array {
+		return array(
+			'rule_id'          => $id,
+			'country'          => 'CA',
+			'to_country'       => 'CA',
+			'from_country'     => $from,
+			'origin_country'   => '',
+			'match_type'       => $match_type,
+			'type'             => 'percentage',
+			'rate'             => $rate,
+			'amount'           => 0,
+			'label'            => $label,
+			'taxable'          => false,
+			'tax_class'        => '',
+			'valuation_method' => 'fob',
+			'base_includes'    => $deps,
+			'stacking_mode'    => $stacking,
+			'priority'         => $priority,
+		);
+	}
+
+	/**
+	 * @testdox A surviving rule whose dependency is wiped by an override is flagged.
+	 *
+	 * Sorted [duty(10), override(5), gst(1)]: the override wipes duty but the
+	 * lower-priority GST survives, and GST still depends on the now-gone duty.
+	 */
+	public function test_surviving_rule_with_dropped_dependency_is_flagged(): void {
+		$rules = array(
+			$this->rule( 'duty', 8, 'Canada Duty (Import)', 'add', 10 ),
+			$this->rule( 'ovr', 3, 'Canada (Custom)', 'override', 5 ),
+			$this->rule( 'gst', 5, 'Canada GST (Import)', 'add', 1, array( 'duty' ) ),
+		);
+
+		$this->assertSame(
+			array( 'Canada GST (Import)' ),
+			\CFWC_Rule_Matcher::detect_broken_dependencies( $rules )
+		);
+	}
+
+	/**
+	 * @testdox Plain additive rules are never flagged.
+	 */
+	public function test_plain_additive_rules_not_flagged(): void {
+		$rules = array(
+			$this->rule( 'duty', 8, 'Canada Duty (Import)', 'add', 10 ),
+			$this->rule( 'gst', 5, 'Canada GST (Import)', 'add', 1, array( 'duty' ) ),
+		);
+
+		$this->assertSame( array(), \CFWC_Rule_Matcher::detect_broken_dependencies( $rules ) );
+	}
+
+	/**
+	 * @testdox When the override wipes the whole chain (dependent included) nothing is flagged.
+	 *
+	 * Override at the lowest priority sorts last and replaces every rule before
+	 * it, so GST itself does not survive. Replacing rules is the documented job
+	 * of override/exclusive, so case (a) deliberately does not report this.
+	 */
+	public function test_whole_chain_replacement_not_flagged(): void {
+		$rules = array(
+			$this->rule( 'duty', 8, 'Canada Duty (Import)', 'add', 10 ),
+			$this->rule( 'gst', 5, 'Canada GST (Import)', 'add', 5, array( 'duty' ) ),
+			$this->rule( 'ovr', 3, 'Canada (Custom)', 'override', 1 ),
+		);
+
+		$this->assertSame( array(), \CFWC_Rule_Matcher::detect_broken_dependencies( $rules ) );
+	}
+
+	/**
+	 * @testdox An exclusive rule that leaves no dependent surviving is not flagged.
+	 */
+	public function test_exclusive_leaving_no_dependent_not_flagged(): void {
+		$rules = array(
+			$this->rule( 'excl', 9, 'Canada (Custom)', 'exclusive', 10 ),
+			$this->rule( 'duty', 8, 'Canada Duty (Import)', 'add', 5 ),
+			$this->rule( 'gst', 5, 'Canada GST (Import)', 'add', 1, array( 'duty' ) ),
+		);
+
+		// Only the exclusive rule survives; GST is gone, so there is no surviving
+		// dependent to warn about.
+		$this->assertSame( array(), \CFWC_Rule_Matcher::detect_broken_dependencies( $rules ) );
+	}
+
+	/**
+	 * @testdox Category/HS-code rules are excluded from the static check.
+	 *
+	 * Their co-occurrence is product-dependent, so they are left to the
+	 * calculator's runtime warning rather than flagged at save time.
+	 */
+	public function test_category_rules_excluded(): void {
+		$rules = array(
+			$this->rule( 'duty', 8, 'Canada Duty (Import)', 'add', 10, array(), 'category' ),
+			$this->rule( 'ovr', 3, 'Canada (Custom)', 'override', 5, array(), 'category' ),
+			$this->rule( 'gst', 5, 'Canada GST (Import)', 'add', 1, array( 'duty' ), 'category' ),
+		);
+
+		$this->assertSame( array(), \CFWC_Rule_Matcher::detect_broken_dependencies( $rules ) );
+	}
+
+	/**
+	 * @testdox Rules restricted to the same origin are analysed together and flagged.
+	 */
+	public function test_same_origin_restricted_rules_are_flagged(): void {
+		$rules = array(
+			$this->rule( 'duty', 8, 'Canada Duty (Import)', 'add', 10, array(), 'all', 'US' ),
+			$this->rule( 'ovr', 3, 'Canada (Custom)', 'override', 5, array(), 'all', 'US' ),
+			$this->rule( 'gst', 5, 'Canada GST (Import)', 'add', 1, array( 'duty' ), 'all', 'US' ),
+		);
+
+		$this->assertSame(
+			array( 'Canada GST (Import)' ),
+			\CFWC_Rule_Matcher::detect_broken_dependencies( $rules )
+		);
+	}
+
+	/**
+	 * @testdox An origin-restricted override breaking an any-origin dependent is flagged.
+	 *
+	 * Mirrors the real saved state: duty + override carry an origin (CA) while
+	 * the GST rule applies to any origin. For a CA-origin product all three
+	 * co-occur, so the override wipes duty and the surviving GST is left
+	 * compounding on an incomplete base.
+	 */
+	public function test_mixed_any_and_specific_origin_is_flagged(): void {
+		$rules = array(
+			$this->rule( 'duty', 8, 'Canada Duty (Import)', 'add', 10, array(), 'all', 'CA' ),
+			$this->rule( 'ovr', 3, 'Canada (Custom)', 'override', 5, array(), 'all', 'CA' ),
+			$this->rule( 'gst', 5, 'Canada GST (Import)', 'add', 1, array( 'duty' ), 'all', '' ),
+		);
+
+		$this->assertSame(
+			array( 'Canada GST (Import)' ),
+			\CFWC_Rule_Matcher::detect_broken_dependencies( $rules )
+		);
+	}
+
+	/**
+	 * @testdox Rules restricted to different origins are never analysed together (no false positive).
+	 *
+	 * The duty/override apply only to US-origin products; the GST rule only to
+	 * CA-origin products. No single product matches both groups, so the GST
+	 * dependency on the (different-origin) duty is not a stacking break.
+	 */
+	public function test_different_origin_rules_not_flagged(): void {
+		$rules = array(
+			$this->rule( 'duty', 8, 'US Duty', 'add', 10, array(), 'all', 'US' ),
+			$this->rule( 'ovr', 3, 'US Override', 'override', 5, array(), 'all', 'US' ),
+			$this->rule( 'gst', 5, 'Canada GST (Import)', 'add', 1, array( 'duty' ), 'all', 'CA' ),
+		);
+
+		$this->assertSame( array(), \CFWC_Rule_Matcher::detect_broken_dependencies( $rules ) );
+	}
+
+	/**
+	 * @testdox The dismissal signature is order-independent and empty for no conflict.
+	 */
+	public function test_signature_is_order_independent_and_empty_for_none(): void {
+		$this->assertSame( '', \CFWC_Rule_Matcher::broken_dependency_signature( array() ) );
+
+		$this->assertSame(
+			\CFWC_Rule_Matcher::broken_dependency_signature( array( 'Canada GST (Import)', 'EU VAT (Import)' ) ),
+			\CFWC_Rule_Matcher::broken_dependency_signature( array( 'EU VAT (Import)', 'Canada GST (Import)' ) ),
+			'Signature must not depend on label order.'
+		);
+	}
+
+	/**
+	 * @testdox A changed set of affected rules produces a different signature so the notice re-surfaces.
+	 */
+	public function test_signature_changes_when_affected_rules_change(): void {
+		$this->assertNotSame(
+			\CFWC_Rule_Matcher::broken_dependency_signature( array( 'Canada GST (Import)' ) ),
+			\CFWC_Rule_Matcher::broken_dependency_signature( array( 'Canada GST (Import)', 'EU VAT (Import)' ) )
+		);
+	}
+}

--- a/tests/Unit/Calculator_Compounding_Test.php
+++ b/tests/Unit/Calculator_Compounding_Test.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Integration tests for compound (base_includes) fee calculation at the cart.
+ *
+ * Verifies the CUSFEES-12 fix end-to-end: a dependent tax rule computes its
+ * percentage on a base that includes the upstream duty fee.
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\CustomsFees\Tests\Unit;
+
+/**
+ * @covers \CFWC_Calculator::calculate_fees
+ */
+class Calculator_Compounding_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Set up store + cart fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		update_option( 'woocommerce_currency', 'USD' );
+		update_option( 'cfwc_valuation_method', 'fob' );
+
+		if ( null === WC()->cart ) {
+			wc_load_cart();
+		}
+		WC()->cart->empty_cart();
+
+		// The fee hook runs against a single shared CFWC_Calculator instance that
+		// memoizes rules in a private $rules_cache. The static clear_cache()
+		// cannot reset that memo (CUSFEES-12 finding #8), so without this reset
+		// a prior test's rules would leak into this one. Clear it via reflection.
+		$this->reset_calculator_memo();
+	}
+
+	/**
+	 * Tear down fixtures.
+	 */
+	public function tearDown(): void {
+		WC()->cart->empty_cart();
+		delete_option( 'cfwc_rules' );
+		delete_transient( 'cfwc_rules_cache' );
+		\CFWC_Calculator::clear_cache();
+		parent::tearDown();
+	}
+
+	/**
+	 * Null the shared calculator's in-memory rule cache so each test reads its
+	 * own rules. Works around the static clear_cache() not resetting the memo.
+	 */
+	private function reset_calculator_memo(): void {
+		delete_transient( 'cfwc_rules_cache' );
+
+		if ( ! class_exists( 'CFWC_Loader' ) ) {
+			return;
+		}
+
+		$loader     = \CFWC_Loader::instance();
+		$loader_ref = new \ReflectionClass( $loader );
+		if ( ! $loader_ref->hasProperty( 'calculator' ) ) {
+			return;
+		}
+
+		$calc_prop = $loader_ref->getProperty( 'calculator' );
+		$calc_prop->setAccessible( true );
+		$calculator = $calc_prop->getValue( $loader );
+		if ( ! $calculator ) {
+			return;
+		}
+
+		$calc_ref = new \ReflectionClass( $calculator );
+		if ( $calc_ref->hasProperty( 'rules_cache' ) ) {
+			$cache_prop = $calc_ref->getProperty( 'rules_cache' );
+			$cache_prop->setAccessible( true );
+			$cache_prop->setValue( $calculator, null );
+		}
+	}
+
+	/**
+	 * Create a simple product at the given price.
+	 *
+	 * @param float $price Product price.
+	 * @return int Product ID.
+	 */
+	private function make_product( float $price ): int {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'CFWC Compounding Test' );
+		$product->set_regular_price( (string) $price );
+		$product->set_price( (string) $price );
+
+		return $product->save();
+	}
+
+	/**
+	 * Build a CA rule with the given id, rate, and dependencies.
+	 *
+	 * @param string $id   Rule ID.
+	 * @param float  $rate Percentage rate.
+	 * @param string $label Display label.
+	 * @param array  $deps base_includes dependency ids.
+	 * @return array Rule data.
+	 */
+	private function ca_rule( string $id, float $rate, string $label, array $deps = array() ): array {
+		return array(
+			'rule_id'          => $id,
+			'country'          => 'CA',
+			'to_country'       => 'CA',
+			'from_country'     => '',
+			'match_type'       => 'all',
+			'type'             => 'percentage',
+			'rate'             => $rate,
+			'amount'           => 0,
+			'label'            => $label,
+			'taxable'          => false,
+			'tax_class'        => '',
+			'valuation_method' => 'fob',
+			'base_includes'    => $deps,
+			'stacking_mode'    => 'add',
+			'priority'         => 0,
+		);
+	}
+
+	/**
+	 * Add a $100 product, ship to Canada, recalculate, and total the customs fees.
+	 *
+	 * @return float Sum of all cart fees.
+	 */
+	private function calculate_total_fees(): float {
+		$product_id = $this->make_product( 100 );
+
+		WC()->customer->set_shipping_country( 'CA' );
+		WC()->customer->set_billing_country( 'CA' );
+		WC()->cart->add_to_cart( $product_id, 1 );
+		WC()->cart->calculate_totals();
+
+		$total = 0.0;
+		foreach ( WC()->cart->get_fees() as $fee ) {
+			$total += (float) $fee->amount;
+		}
+		return $total;
+	}
+
+	/**
+	 * @testdox A dependent tax rule compounds on the upstream duty fee.
+	 *
+	 * duty: 8% FOB on $100 = $8.00; gst: 5% FOB on ($100 + $8) = $5.40; total $13.40.
+	 */
+	public function test_dependent_rule_compounds_on_duty(): void {
+		update_option(
+			'cfwc_rules',
+			array(
+				$this->ca_rule( 'duty', 8, 'CA Duty' ),
+				$this->ca_rule( 'gst', 5, 'CA GST', array( 'duty' ) ),
+			)
+		);
+		$this->reset_calculator_memo();
+
+		$this->assertEqualsWithDelta(
+			13.40,
+			$this->calculate_total_fees(),
+			0.001,
+			'GST must compound on duty: 8%*100 + 5%*(100+8) = 13.40.'
+		);
+	}
+
+	/**
+	 * @testdox Without a dependency, the same two rules are additive on their own bases.
+	 *
+	 * duty: 8% FOB on $100 = $8.00; gst: 5% FOB on $100 = $5.00; total = $13.00.
+	 */
+	public function test_independent_rules_do_not_compound(): void {
+		update_option(
+			'cfwc_rules',
+			array(
+				$this->ca_rule( 'duty', 8, 'CA Duty' ),
+				$this->ca_rule( 'gst', 5, 'CA GST' ),
+			)
+		);
+		$this->reset_calculator_memo();
+
+		$this->assertEqualsWithDelta(
+			13.00,
+			$this->calculate_total_fees(),
+			0.001,
+			'Independent rules must not compound: 8%*100 + 5%*100 = 13.00.'
+		);
+	}
+}

--- a/tests/Unit/Calculator_Compounding_Test.php
+++ b/tests/Unit/Calculator_Compounding_Test.php
@@ -126,6 +126,24 @@ class Calculator_Compounding_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Build a CA rule with an explicit stacking mode and priority.
+	 *
+	 * @param string $id       Rule ID.
+	 * @param float  $rate     Percentage rate.
+	 * @param string $label    Display label.
+	 * @param string $stacking Stacking mode (add|override|exclusive).
+	 * @param int    $priority Priority (higher sorts first).
+	 * @param array  $deps     base_includes dependency ids.
+	 * @return array Rule data.
+	 */
+	private function ca_rule_stacked( string $id, float $rate, string $label, string $stacking, int $priority, array $deps = array() ): array {
+		$rule                  = $this->ca_rule( $id, $rate, $label, $deps );
+		$rule['stacking_mode'] = $stacking;
+		$rule['priority']      = $priority;
+		return $rule;
+	}
+
+	/**
 	 * Add a $100 product, ship to Canada, recalculate, and total the customs fees.
 	 *
 	 * @return float Sum of all cart fees.
@@ -188,6 +206,36 @@ class Calculator_Compounding_Test extends \WC_Unit_Test_Case {
 			$this->calculate_total_fees(),
 			0.001,
 			'Independent rules must not compound: 8%*100 + 5%*100 = 13.00.'
+		);
+	}
+
+	/**
+	 * @testdox A dependency removed by an override rule does not compound; the dependent fee falls back to its own base.
+	 *
+	 * Sorted by priority the set is [duty(10), override(5), gst(1)]. The override
+	 * wipes the higher-priority duty rule but allows the subsequent GST rule, so
+	 * the survivors are [override, gst]. GST still declares base_includes=[duty],
+	 * but duty is gone, so GST computes on its own $100 base (5.00) rather than
+	 * the compounded $108 base (5.40). With the override adding 3% = 3.00 the
+	 * total is 8.00 — proving the stacking-dropped dependency is not silently
+	 * compounded. (Were it still compounding, the total would be 8.40.)
+	 */
+	public function test_stacking_dropped_dependency_falls_back_to_own_base(): void {
+		update_option(
+			'cfwc_rules',
+			array(
+				$this->ca_rule_stacked( 'duty', 8, 'CA Duty', 'add', 10 ),
+				$this->ca_rule_stacked( 'ovr', 3, 'CA Override', 'override', 5 ),
+				$this->ca_rule_stacked( 'gst', 5, 'CA GST', 'add', 1, array( 'duty' ) ),
+			)
+		);
+		$this->reset_calculator_memo();
+
+		$this->assertEqualsWithDelta(
+			8.00,
+			$this->calculate_total_fees(),
+			0.001,
+			'Override drops duty; GST must fall back to own base: 3 + 5%*100 = 8.00, not 3 + 5%*108 = 8.40.'
 		);
 	}
 }

--- a/tests/Unit/Cycle_Detection_Test.php
+++ b/tests/Unit/Cycle_Detection_Test.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Unit tests for base_includes dependency cycle detection in CFWC_Calculator.
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\CustomsFees\Tests\Unit;
+
+/**
+ * @covers \CFWC_Calculator::has_cycle
+ * @covers \CFWC_Calculator::detect_cycle_labels
+ */
+class Cycle_Detection_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Build a minimal rule with a rule_id and a base_includes list.
+	 *
+	 * @param string $id   Rule ID.
+	 * @param array  $deps Dependency rule IDs.
+	 * @return array Rule data.
+	 */
+	private function rule( string $id, array $deps = array() ): array {
+		return array(
+			'rule_id'       => $id,
+			'label'         => $id,
+			'base_includes' => $deps,
+		);
+	}
+
+	/**
+	 * Cycle membership scenarios.
+	 *
+	 * @return array<string,array{0:array<int,array<string,mixed>>,1:string,2:bool}>
+	 */
+	public function cycle_membership_data(): array {
+		$self    = array( $this->rule( 'A', array( 'A' ) ) );
+		$mutual  = array( $this->rule( 'A', array( 'B' ) ), $this->rule( 'B', array( 'A' ) ) );
+		$diamond = array(
+			$this->rule( 'A', array( 'B', 'C' ) ),
+			$this->rule( 'B' ),
+			$this->rule( 'C', array( 'B' ) ),
+		);
+		$preset   = array( $this->rule( 'gst', array( 'duty' ) ), $this->rule( 'duty' ) );
+		$upstream = array(
+			$this->rule( 'X', array( 'A' ) ),
+			$this->rule( 'A', array( 'B' ) ),
+			$this->rule( 'B', array( 'A' ) ),
+		);
+
+		return array(
+			'self-loop is a cycle'               => array( $self, 'A', true ),
+			'mutual A<->B: A is a cycle'         => array( $mutual, 'A', true ),
+			'mutual A<->B: B is a cycle'         => array( $mutual, 'B', true ),
+			'diamond apex is not a cycle'        => array( $diamond, 'A', false ),
+			'diamond shared dep is not a cycle'  => array( $diamond, 'C', false ),
+			'canada gst->duty is not a cycle'    => array( $preset, 'gst', false ),
+			'upstream of a cycle is not a cycle' => array( $upstream, 'X', false ),
+			'unknown rule id is not a cycle'     => array( $preset, 'missing', false ),
+		);
+	}
+
+	/**
+	 * @testdox has_cycle() flags only rules that loop back to themselves.
+	 * @dataProvider cycle_membership_data
+	 *
+	 * @param array  $rules    Rule set.
+	 * @param string $start_id Rule under test.
+	 * @param bool   $expected Whether the rule participates in a cycle.
+	 */
+	public function test_has_cycle_membership( array $rules, string $start_id, bool $expected ): void {
+		$this->assertSame(
+			$expected,
+			\CFWC_Calculator::has_cycle( $rules, $start_id ),
+			"has_cycle() returned the wrong result for '{$start_id}'."
+		);
+	}
+
+	/**
+	 * @testdox detect_cycle_labels() returns only the rules inside the cycle, deduplicated.
+	 */
+	public function test_detect_cycle_labels_returns_only_cyclic_rules(): void {
+		$rules = array(
+			$this->rule( 'X', array( 'A' ) ),
+			$this->rule( 'A', array( 'B' ) ),
+			$this->rule( 'B', array( 'A' ) ),
+		);
+
+		$labels = \CFWC_Calculator::detect_cycle_labels( $rules );
+		sort( $labels );
+
+		$this->assertSame(
+			array( 'A', 'B' ),
+			$labels,
+			'Only the two mutually-dependent rules should be reported as cyclic.'
+		);
+	}
+
+	/**
+	 * @testdox detect_cycle_labels() returns an empty array for an acyclic rule set.
+	 */
+	public function test_detect_cycle_labels_empty_when_acyclic(): void {
+		$rules = array(
+			$this->rule( 'gst', array( 'duty' ) ),
+			$this->rule( 'duty' ),
+		);
+
+		$this->assertSame(
+			array(),
+			\CFWC_Calculator::detect_cycle_labels( $rules ),
+			'An acyclic rule set must report no cyclic labels.'
+		);
+	}
+}

--- a/tests/Unit/Migrate_Rules_Test.php
+++ b/tests/Unit/Migrate_Rules_Test.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Unit tests for the per-rule field migration in CFWC_Settings::migrate_rules().
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\CustomsFees\Tests\Unit;
+
+/**
+ * @covers \CFWC_Settings::migrate_rules
+ */
+class Migrate_Rules_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox migrate_rules() backfills the v1.2.0 fields on a legacy rule.
+	 */
+	public function test_backfills_missing_fields(): void {
+		$legacy = array(
+			array(
+				'country' => 'CA',
+				'type'    => 'percentage',
+				'rate'    => 5,
+				'label'   => 'Legacy',
+			),
+		);
+
+		$migrated = \CFWC_Settings::migrate_rules( $legacy );
+
+		$this->assertNotEmpty( $migrated[0]['rule_id'], 'A rule_id must be assigned.' );
+		$this->assertSame( 'inherit', $migrated[0]['valuation_method'], 'Default valuation must be inherit.' );
+		$this->assertSame( array(), $migrated[0]['base_includes'], 'base_includes must default to an empty array.' );
+	}
+
+	/**
+	 * @testdox migrate_rules() is idempotent: a second pass does not rotate the rule_id.
+	 */
+	public function test_is_idempotent(): void {
+		$legacy = array(
+			array(
+				'country' => 'CA',
+				'type'    => 'percentage',
+				'rate'    => 5,
+				'label'   => 'Legacy',
+			),
+		);
+
+		$first  = \CFWC_Settings::migrate_rules( $legacy );
+		$second = \CFWC_Settings::migrate_rules( $first );
+
+		$this->assertSame(
+			$first[0]['rule_id'],
+			$second[0]['rule_id'],
+			'A stable rule_id must survive a second migration pass.'
+		);
+	}
+
+	/**
+	 * @testdox migrate_rules() preserves an existing rule_id and valid valuation_method.
+	 */
+	public function test_preserves_existing_values(): void {
+		$rules = array(
+			array(
+				'rule_id'          => 'canada_gst_duty',
+				'country'          => 'CA',
+				'type'             => 'percentage',
+				'rate'             => 8,
+				'label'            => 'Canada Duty (Import)',
+				'valuation_method' => 'fob',
+				'base_includes'    => array(),
+			),
+		);
+
+		$migrated = \CFWC_Settings::migrate_rules( $rules );
+
+		$this->assertSame( 'canada_gst_duty', $migrated[0]['rule_id'], 'An existing rule_id must be preserved.' );
+		$this->assertSame( 'fob', $migrated[0]['valuation_method'], 'A valid valuation_method must be preserved.' );
+	}
+
+	/**
+	 * @testdox migrate_rules() normalizes an invalid valuation_method back to inherit.
+	 */
+	public function test_normalizes_invalid_valuation_method(): void {
+		$rules = array(
+			array(
+				'rule_id'          => 'r1',
+				'country'          => 'CA',
+				'type'             => 'percentage',
+				'rate'             => 8,
+				'label'            => 'Bad valuation',
+				'valuation_method' => 'bogus',
+				'base_includes'    => array(),
+			),
+		);
+
+		$migrated = \CFWC_Settings::migrate_rules( $rules );
+
+		$this->assertSame(
+			'inherit',
+			$migrated[0]['valuation_method'],
+			'An unrecognized valuation_method must fall back to inherit.'
+		);
+	}
+
+	/**
+	 * @testdox migrate_rules() returns an empty array for non-array input.
+	 */
+	public function test_returns_empty_array_for_non_array_input(): void {
+		$this->assertSame(
+			array(),
+			\CFWC_Settings::migrate_rules( 'not-an-array' ),
+			'Non-array input must yield an empty array, never a fatal.'
+		);
+	}
+}

--- a/tests/Unit/Preset_Append_Test.php
+++ b/tests/Unit/Preset_Append_Test.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Unit tests for compound-preset behavior in CFWC_Templates::apply_template().
+ *
+ * Covers CUSFEES-12 finding #1: appending a two-rule compound preset (duty +
+ * tax-with-base_includes) to a store that already has a general rule for the
+ * same destination silently drops the new rules, so the dependency that makes
+ * the fix work is never added.
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\CustomsFees\Tests\Unit;
+
+/**
+ * @covers \CFWC_Templates::apply_template
+ */
+class Preset_Append_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var \CFWC_Templates
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new \CFWC_Templates();
+		delete_option( 'cfwc_rules' );
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	public function tearDown(): void {
+		delete_option( 'cfwc_rules' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Find a saved rule by its label.
+	 *
+	 * @param array  $rules Saved rules.
+	 * @param string $label Label to match.
+	 * @return array|null The matching rule, or null.
+	 */
+	private function find_by_label( array $rules, string $label ): ?array {
+		foreach ( $rules as $rule ) {
+			if ( isset( $rule['label'] ) && $label === $rule['label'] ) {
+				return $rule;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * A pre-existing manual general rule for Canada (different rule_id than the preset).
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	private function existing_canada_duty_rule(): array {
+		return array(
+			array(
+				'rule_id'          => 'manual_uuid_123',
+				'country'          => 'CA',
+				'to_country'       => 'CA',
+				'from_country'     => '',
+				'match_type'       => 'all',
+				'type'             => 'percentage',
+				'rate'             => 8,
+				'amount'           => 0,
+				'label'            => 'Canada Duty (Import)',
+				'taxable'          => false,
+				'tax_class'        => '',
+				'valuation_method' => 'inherit',
+				'base_includes'    => array(),
+				'stacking_mode'    => 'add',
+				'priority'         => 0,
+			),
+		);
+	}
+
+	/**
+	 * @testdox Appending the Canada preset to an empty store links GST to duty.
+	 */
+	public function test_append_to_empty_store_links_dependency(): void {
+		$this->sut->apply_template( 'canada_gst', true );
+
+		$rules = get_option( 'cfwc_rules', array() );
+		$gst   = $this->find_by_label( $rules, 'Canada GST (Import)' );
+		$duty  = $this->find_by_label( $rules, 'Canada Duty (Import)' );
+
+		$this->assertNotNull( $duty, 'The duty rule should be added.' );
+		$this->assertNotNull( $gst, 'The GST rule should be added.' );
+		$this->assertContains(
+			$duty['rule_id'],
+			$gst['base_includes'],
+			'GST must depend on the duty rule so its base is CIF + Duty.'
+		);
+	}
+
+	/**
+	 * @testdox CHARACTERIZATION (current bug): appending over an existing general CA rule drops the new rules.
+	 *
+	 * Documents the behavior observed during the CUSFEES-12 review. The
+	 * "conflicting general rules" dedup heuristic in apply_template() drops any
+	 * new general rule for a destination that already has one, regardless of
+	 * label, so both compound-preset rules are silently discarded. Update this
+	 * test (and remove the skip on the desired-behavior test below) once the
+	 * dedup logic is fixed.
+	 */
+	public function test_append_over_existing_general_rule_drops_new_rules_current_behavior(): void {
+		update_option( 'cfwc_rules', $this->existing_canada_duty_rule() );
+
+		$this->sut->apply_template( 'canada_gst', true );
+
+		$rules = get_option( 'cfwc_rules', array() );
+
+		$this->assertCount(
+			1,
+			$rules,
+			'Current behavior: appending the compound Canada preset over an existing general CA rule adds nothing.'
+		);
+		$this->assertNull(
+			$this->find_by_label( $rules, 'Canada GST (Import)' ),
+			'Current behavior: the GST rule is silently dropped, so the compliance fix is not adopted.'
+		);
+	}
+
+	/**
+	 * @testdox DESIRED (Finding #1 fix): appending the preset preserves the GST->duty dependency.
+	 */
+	public function test_append_over_existing_general_rule_preserves_dependency_desired(): void {
+		$this->markTestSkipped(
+			'CUSFEES-12 finding #1: apply_template drops compound-preset rules when a general rule '
+			. 'for the same destination already exists. Unskip once the dedup heuristic is fixed.'
+		);
+
+		update_option( 'cfwc_rules', $this->existing_canada_duty_rule() );
+
+		$this->sut->apply_template( 'canada_gst', true );
+
+		$rules = get_option( 'cfwc_rules', array() );
+		$gst   = $this->find_by_label( $rules, 'Canada GST (Import)' );
+
+		$this->assertNotNull( $gst, 'The GST rule should be added even when a duty rule already exists.' );
+		$this->assertNotEmpty( $gst['base_includes'], 'The GST rule must keep a resolvable duty dependency.' );
+
+		$dep_id     = $gst['base_includes'][0];
+		$dep_exists = false;
+		foreach ( $rules as $rule ) {
+			if ( isset( $rule['rule_id'] ) && $dep_id === $rule['rule_id'] ) {
+				$dep_exists = true;
+				break;
+			}
+		}
+		$this->assertTrue( $dep_exists, 'The GST dependency must point at a rule that actually exists (no dangling id).' );
+	}
+}

--- a/tests/Unit/Preset_Append_Test.php
+++ b/tests/Unit/Preset_Append_Test.php
@@ -106,60 +106,101 @@ class Preset_Append_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox CHARACTERIZATION (current bug): appending over an existing general CA rule drops the new rules.
+	 * @testdox Appending the compound preset over an existing general CA rule adds the GST rule and remaps its dependency.
 	 *
-	 * Documents the behavior observed during the CUSFEES-12 review. The
-	 * "conflicting general rules" dedup heuristic in apply_template() drops any
-	 * new general rule for a destination that already has one, regardless of
-	 * label, so both compound-preset rules are silently discarded. Update this
-	 * test (and remove the skip on the desired-behavior test below) once the
-	 * dedup logic is fixed.
+	 * Regression coverage for CUSFEES-12 finding #1. Previously, the
+	 * "conflicting general rules" dedup heuristic in apply_template() dropped
+	 * any new general rule for a destination that already had one, regardless
+	 * of label, silently discarding the GST rule and leaving the merchant
+	 * non-compliant. The fix: detect duplicates by label and remap the GST
+	 * rule's base_includes onto the existing duty rule's rule_id.
 	 */
-	public function test_append_over_existing_general_rule_drops_new_rules_current_behavior(): void {
-		update_option( 'cfwc_rules', $this->existing_canada_duty_rule() );
+	public function test_append_over_existing_general_rule_preserves_dependency(): void {
+		$existing = $this->existing_canada_duty_rule();
+		update_option( 'cfwc_rules', $existing );
 
-		$this->sut->apply_template( 'canada_gst', true );
+		$result = $this->sut->apply_template( 'canada_gst', true );
 
-		$rules = get_option( 'cfwc_rules', array() );
-
-		$this->assertCount(
-			1,
-			$rules,
-			'Current behavior: appending the compound Canada preset over an existing general CA rule adds nothing.'
-		);
-		$this->assertNull(
-			$this->find_by_label( $rules, 'Canada GST (Import)' ),
-			'Current behavior: the GST rule is silently dropped, so the compliance fix is not adopted.'
-		);
-	}
-
-	/**
-	 * @testdox DESIRED (Finding #1 fix): appending the preset preserves the GST->duty dependency.
-	 */
-	public function test_append_over_existing_general_rule_preserves_dependency_desired(): void {
-		$this->markTestSkipped(
-			'CUSFEES-12 finding #1: apply_template drops compound-preset rules when a general rule '
-			. 'for the same destination already exists. Unskip once the dedup heuristic is fixed.'
-		);
-
-		update_option( 'cfwc_rules', $this->existing_canada_duty_rule() );
-
-		$this->sut->apply_template( 'canada_gst', true );
+		$this->assertIsArray( $result );
+		$this->assertSame( 1, $result['added'], 'GST rule should be added.' );
+		$this->assertSame( 1, $result['duplicates'], 'Duty rule should be detected as the duplicate.' );
 
 		$rules = get_option( 'cfwc_rules', array() );
 		$gst   = $this->find_by_label( $rules, 'Canada GST (Import)' );
 
+		$this->assertCount( 2, $rules, 'Existing duty + new GST should be present.' );
 		$this->assertNotNull( $gst, 'The GST rule should be added even when a duty rule already exists.' );
 		$this->assertNotEmpty( $gst['base_includes'], 'The GST rule must keep a resolvable duty dependency.' );
+		$this->assertSame(
+			$existing[0]['rule_id'],
+			$gst['base_includes'][0],
+			'GST base_includes must be remapped to the existing duty rule_id, not the preset placeholder.'
+		);
+	}
 
-		$dep_id     = $gst['base_includes'][0];
-		$dep_exists = false;
-		foreach ( $rules as $rule ) {
-			if ( isset( $rule['rule_id'] ) && $dep_id === $rule['rule_id'] ) {
-				$dep_exists = true;
-				break;
-			}
-		}
-		$this->assertTrue( $dep_exists, 'The GST dependency must point at a rule that actually exists (no dangling id).' );
+	/**
+	 * @testdox Same-label, different-country rule is not treated as a duplicate.
+	 */
+	public function test_append_does_not_dedup_across_countries(): void {
+		update_option(
+			'cfwc_rules',
+			array(
+				array(
+					'rule_id'          => 'manual_us_duty',
+					'country'          => 'US',
+					'to_country'       => 'US',
+					'from_country'     => '',
+					'match_type'       => 'all',
+					'type'             => 'percentage',
+					'rate'             => 5,
+					'amount'           => 0,
+					'label'            => 'Canada Duty (Import)',
+					'taxable'          => false,
+					'tax_class'        => '',
+					'valuation_method' => 'inherit',
+					'base_includes'    => array(),
+				),
+			)
+		);
+
+		$result = $this->sut->apply_template( 'canada_gst', true );
+
+		$this->assertSame( 2, $result['added'], 'Both CA rules should be added; US rule with same label is irrelevant.' );
+		$this->assertSame( 0, $result['duplicates'] );
+	}
+
+	/**
+	 * @testdox Same-country, different-label general rule is not treated as a duplicate.
+	 *
+	 * Guards against re-introducing the over-broad "conflicting general
+	 * rules" heuristic. Two general rules to the same destination with
+	 * distinct labels are the whole point of compound presets.
+	 */
+	public function test_append_does_not_dedup_general_rules_by_country_alone(): void {
+		update_option(
+			'cfwc_rules',
+			array(
+				array(
+					'rule_id'          => 'manual_ca_other',
+					'country'          => 'CA',
+					'to_country'       => 'CA',
+					'from_country'     => '',
+					'match_type'       => 'all',
+					'type'             => 'percentage',
+					'rate'             => 2,
+					'amount'           => 0,
+					'label'            => 'Some Other CA Fee',
+					'taxable'          => false,
+					'tax_class'        => '',
+					'valuation_method' => 'inherit',
+					'base_includes'    => array(),
+				),
+			)
+		);
+
+		$result = $this->sut->apply_template( 'canada_gst', true );
+
+		$this->assertSame( 2, $result['added'], 'Both preset rules should be added; existing rule has a different label.' );
+		$this->assertSame( 0, $result['duplicates'] );
 	}
 }

--- a/tests/Unit/Stacking_Dependency_Drop_Test.php
+++ b/tests/Unit/Stacking_Dependency_Drop_Test.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * Unit tests for stacking-mode vs. base_includes dependency-drop detection.
+ *
+ * Covers the CUSFEES-12 review finding: when an override/exclusive rule removes
+ * a rule that a surviving rule depends on (base_includes), CFWC_Rule_Matcher
+ * records the dropped rule_id so the calculator can warn instead of silently
+ * computing the dependent fee on an un-compounded base.
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\CustomsFees\Tests\Unit;
+
+/**
+ * @covers \CFWC_Rule_Matcher::get_last_stacking_dropped
+ */
+class Stacking_Dependency_Drop_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var \CFWC_Rule_Matcher
+	 */
+	private $matcher;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->matcher = new \CFWC_Rule_Matcher();
+	}
+
+	/**
+	 * Create a simple physical product.
+	 *
+	 * @return \WC_Product_Simple
+	 */
+	private function make_product(): \WC_Product_Simple {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'CFWC Stacking Test' );
+		$product->set_regular_price( '100' );
+		$product->set_price( '100' );
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * Build a general CA rule.
+	 *
+	 * @param string $id       Rule ID.
+	 * @param float  $rate     Percentage rate.
+	 * @param string $label    Display label.
+	 * @param string $stacking Stacking mode (add|override|exclusive).
+	 * @param int    $priority Priority (higher sorts first).
+	 * @param array  $deps     base_includes dependency ids.
+	 * @return array Rule data.
+	 */
+	private function ca_rule( string $id, float $rate, string $label, string $stacking = 'add', int $priority = 0, array $deps = array() ): array {
+		return array(
+			'rule_id'          => $id,
+			'country'          => 'CA',
+			'to_country'       => 'CA',
+			'from_country'     => '',
+			'match_type'       => 'all',
+			'type'             => 'percentage',
+			'rate'             => $rate,
+			'amount'           => 0,
+			'label'            => $label,
+			'taxable'          => false,
+			'tax_class'        => '',
+			'valuation_method' => 'fob',
+			'base_includes'    => $deps,
+			'stacking_mode'    => $stacking,
+			'priority'         => $priority,
+		);
+	}
+
+	/**
+	 * @testdox An override rule that wipes a depended-on duty rule records it as stacking-dropped.
+	 *
+	 * Sorted by priority the set is [duty(10), override(5), gst(1)]: the override
+	 * resets the survivor list (wiping the higher-priority duty rule) but allows
+	 * the subsequent GST rule. GST still declares base_includes=[duty], so the
+	 * dropped duty id must be recorded for the calculator to surface a warning.
+	 */
+	public function test_override_drop_of_dependency_is_recorded(): void {
+		$rules = array(
+			$this->ca_rule( 'duty', 8, 'CA Duty', 'add', 10 ),
+			$this->ca_rule( 'ovr', 3, 'CA Override Fee', 'override', 5 ),
+			$this->ca_rule( 'gst', 5, 'CA GST', 'add', 1, array( 'duty' ) ),
+		);
+
+		$survivors    = $this->matcher->find_matching_rules( $this->make_product(), 'US', 'CA', $rules );
+		$dropped      = $this->matcher->get_last_stacking_dropped();
+		$survivor_ids = wp_list_pluck( $survivors, 'rule_id' );
+
+		$this->assertNotContains( 'duty', $survivor_ids, 'The override should wipe the higher-priority duty rule.' );
+		$this->assertContains( 'gst', $survivor_ids, 'The GST rule added after the override should survive.' );
+		$this->assertContains( 'duty', $dropped, 'The dropped duty dependency must be recorded so the calculator can warn.' );
+	}
+
+	/**
+	 * @testdox An exclusive rule records every other matched rule as stacking-dropped.
+	 */
+	public function test_exclusive_drops_all_other_matches(): void {
+		$rules = array(
+			$this->ca_rule( 'excl', 9, 'CA Exclusive Fee', 'exclusive', 10 ),
+			$this->ca_rule( 'duty', 8, 'CA Duty', 'add', 5 ),
+			$this->ca_rule( 'gst', 5, 'CA GST', 'add', 1, array( 'duty' ) ),
+		);
+
+		$survivors = $this->matcher->find_matching_rules( $this->make_product(), 'US', 'CA', $rules );
+		$dropped   = $this->matcher->get_last_stacking_dropped();
+
+		$this->assertCount( 1, $survivors, 'Only the exclusive rule should survive.' );
+		$this->assertContains( 'duty', $dropped );
+		$this->assertContains( 'gst', $dropped );
+	}
+
+	/**
+	 * @testdox A plain additive rule set drops nothing.
+	 */
+	public function test_additive_rules_drop_nothing(): void {
+		$rules = array(
+			$this->ca_rule( 'duty', 8, 'CA Duty', 'add', 10 ),
+			$this->ca_rule( 'gst', 5, 'CA GST', 'add', 1, array( 'duty' ) ),
+		);
+
+		$this->matcher->find_matching_rules( $this->make_product(), 'US', 'CA', $rules );
+
+		$this->assertSame(
+			array(),
+			$this->matcher->get_last_stacking_dropped(),
+			'With no override/exclusive rule, nothing is stacking-filtered.'
+		);
+	}
+}

--- a/tests/bin/check-test-env.sh
+++ b/tests/bin/check-test-env.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# check-test-env.sh
+#
+# Pre-flight health check for the PHPUnit test environment.
+#
+# Probes the components needed for `composer run test` and, on failure,
+# dispatches a granular repair to install-wc-tests.sh by setting REPAIR_*
+# env vars so only the broken components get rebuilt.
+#
+# The probes are intentionally cheap. The most important one is WP_CONFIG —
+# it catches the cross-plugin /tmp drift where another woocommerce extension
+# (e.g. ShipStation) overwrote /tmp/wordpress-tests-lib/wp-tests-config.php
+# with a different DB_HOST port.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$PROJECT_ROOT/tests/docker-compose.yml"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/test-config.sh"
+
+failed=0
+results=()
+declare -A REPAIR=()
+
+probe() {
+    local label="$1" repair_key="$2"
+    shift 2
+    if "$@" > /dev/null 2>&1; then
+        results+=("   ✅ $label")
+    else
+        results+=("   ❌ $label")
+        failed=1
+        [[ -n "$repair_key" ]] && REPAIR[$repair_key]=1
+    fi
+}
+
+probe_wp_config_db_host() {
+    local cfg="${WP_TESTS_DIR}/wp-tests-config.php"
+    [[ -f "$cfg" ]] || return 1
+    grep -qE "define\(\s*'DB_HOST'\s*,\s*'${TEST_DB_HOST}:${TEST_DB_PORT}'\s*\)" "$cfg"
+}
+
+probe "PHPUnit binary" \
+    VENDOR test -x "$PROJECT_ROOT/vendor/bin/phpunit"
+
+probe "WC test framework" \
+    WC test -f "${WC_DEVELOP_DIR}/tests/legacy/bootstrap.php"
+
+probe "WC composer dependencies" \
+    WC test -f "${WC_DEVELOP_DIR}/vendor/autoload.php"
+
+probe "WC feature config generated" \
+    WC test -f "${WC_DEVELOP_DIR}/includes/react-admin/feature-config.php"
+
+probe "WP core" \
+    WP test -f "${WP_CORE_DIR}/wp-includes/version.php"
+
+probe "WP test library" \
+    WP test -f "${WP_TESTS_DIR}/includes/functions.php"
+
+probe "WP tests config exists" \
+    WP test -f "${WP_TESTS_DIR}/wp-tests-config.php"
+
+probe "WP tests config DB_HOST matches ${TEST_DB_HOST}:${TEST_DB_PORT}" \
+    WP_CONFIG probe_wp_config_db_host
+
+probe "DB container running" \
+    DB bash -c "docker compose -f '$COMPOSE_FILE' ps test_db --status running -q 2>/dev/null | grep -q ."
+
+probe "DB accepting connections at ${TEST_DB_HOST}:${TEST_DB_PORT}" \
+    DB_PORT bash -c "(echo > /dev/tcp/${TEST_DB_HOST}/${TEST_DB_PORT}) 2>/dev/null"
+
+if [ "$failed" = "1" ]; then
+    echo
+    echo "❌ PHPUnit test environment is not ready:"
+    echo
+    for line in "${results[@]}"; do
+        echo "$line"
+    done
+    echo
+    echo "▶️  Running install-wc-tests.sh (granular repair)..."
+    echo "   Components to repair:" \
+        "${REPAIR[VENDOR]:+VENDOR}" \
+        "${REPAIR[WC]:+WC}" \
+        "${REPAIR[WP]:+WP}" \
+        "${REPAIR[WP_CONFIG]:+WP_CONFIG}" \
+        "${REPAIR[DB]:+DB}" \
+        "${REPAIR[DB_PORT]:+DB_PORT}"
+    echo "   ℹ️  To force a full reinstall instead, run:  bash tests/bin/install-wc-tests.sh --force"
+    echo
+    exec env \
+        REPAIR_DISPATCHED=1 \
+        REPAIR_VENDOR="${REPAIR[VENDOR]-0}" \
+        REPAIR_WC="${REPAIR[WC]-0}" \
+        REPAIR_WP="${REPAIR[WP]-0}" \
+        REPAIR_WP_CONFIG="${REPAIR[WP_CONFIG]-0}" \
+        REPAIR_DB="${REPAIR[DB]-0}" \
+        REPAIR_DB_PORT="${REPAIR[DB_PORT]-0}" \
+        bash "$SCRIPT_DIR/install-wc-tests.sh"
+fi
+
+# Healthy path. Stay quiet when chained from run-tests.sh; print a confirmation
+# only when invoked directly.
+if [[ -n "${REENTRY_FROM_SETUP:-}" ]]; then
+    echo "✅ Test environment is ready. Nothing to repair."
+    echo "   To force a full reinstall anyway, run:  bash tests/bin/install-wc-tests.sh --force"
+fi

--- a/tests/bin/install-wc-tests.sh
+++ b/tests/bin/install-wc-tests.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# install-wc-tests.sh
+#
+# Repairs the WordPress + WooCommerce test environment for PHPUnit.
+#
+# Normally invoked indirectly by check-test-env.sh, which sets only the
+# REPAIR_* env vars for components that probed unhealthy. Each repair function
+# is independent and is only run when its flag is set, so the cross-plugin
+# /tmp drift case (wrong DB port baked into wp-tests-config.php after another
+# extension's setup ran first) is repaired with a single sed — no downloads,
+# no svn, no git clone.
+#
+# Usage:
+#   tests/bin/install-wc-tests.sh                # health-check first, repair only what's broken
+#   tests/bin/install-wc-tests.sh --force        # reinstall every component
+#   REPAIR_WP_CONFIG=1 tests/bin/install-wc-tests.sh   # repair only the wp-tests-config.php DB_HOST
+#
+# Granular repair flags (env vars, "1" to enable):
+#   REPAIR_VENDOR     plugin composer install (vendor/bin/phpunit)
+#   REPAIR_WC         re-clone /tmp/woocommerce + composer + pnpm + feature-config
+#   REPAIR_WP         re-install /tmp/wordpress + /tmp/wordpress-tests-lib (svn)
+#                     and re-run WC's install.sh to bootstrap the test DB
+#   REPAIR_WP_CONFIG  rewrite /tmp/wordpress-tests-lib/wp-tests-config.php DB_HOST
+#                     in place (fast path; no downloads)
+#   REPAIR_DB         docker compose down -v + up -d (wipes DB volume)
+#   REPAIR_DB_PORT    wait for DB to accept TCP connections (no rebuild)
+
+set -e
+
+trap 'echo "❌ install-wc-tests.sh failed on line $LINENO."; exit 1' ERR
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+COMPOSE_FILE="$PROJECT_ROOT/tests/docker-compose.yml"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/test-config.sh"
+
+# Parse flags. With --force, repair everything. With no flags and no
+# REPAIR_DISPATCHED sentinel, defer to the health check first — it will exec
+# back here with the right REPAIR_* set, only if something is actually broken.
+if [[ "${1:-}" == "--force" ]]; then
+    shift
+    REPAIR_VENDOR=1
+    REPAIR_WC=1
+    REPAIR_WP=1
+    REPAIR_WP_CONFIG=1
+    REPAIR_DB=1
+    REPAIR_DB_PORT=1
+elif [[ -z "${REPAIR_DISPATCHED:-}" \
+        && -z "${REPAIR_VENDOR:-}${REPAIR_WC:-}${REPAIR_WP:-}${REPAIR_WP_CONFIG:-}${REPAIR_DB:-}${REPAIR_DB_PORT:-}" ]]; then
+    exec env REENTRY_FROM_SETUP=1 bash "$SCRIPT_DIR/check-test-env.sh"
+fi
+
+: "${REPAIR_VENDOR:=0}"
+: "${REPAIR_WC:=0}"
+: "${REPAIR_WP:=0}"
+: "${REPAIR_WP_CONFIG:=0}"
+: "${REPAIR_DB:=0}"
+: "${REPAIR_DB_PORT:=0}"
+
+# Cascades: wiping the DB volume or re-cloning WC means the test DB schema
+# must be re-bootstrapped (which also rewrites wp-tests-config.php).
+[[ "$REPAIR_DB" == "1" ]] && REPAIR_WP=1
+[[ "$REPAIR_WC" == "1" ]] && REPAIR_WP=1
+# Re-running WC's install.sh writes a fresh wp-tests-config.php, so an explicit
+# WP_CONFIG repair is redundant when REPAIR_WP is set.
+[[ "$REPAIR_WP" == "1" ]] && REPAIR_WP_CONFIG=0
+
+WP_VERSION=${EXPECTED_WP_VERSION:-latest}
+WC_VERSION=${WC_VERSION:-latest}
+DB_HOST="${TEST_DB_HOST}:${TEST_DB_PORT}"
+
+# ---------------------------------------------------------------------------
+# mysql / mysqladmin shims — proxy through the DB container so the test env
+# is self-contained and does not require a local mysql client. We materialise
+# real executables on disk (not shell functions) and prepend their directory
+# to PATH, because WC's tests/bin/install.sh uses `which mysqladmin` to verify
+# availability — and `which` is external, so it cannot see exported functions.
+#
+# The shim rewrites connection args so the in-container client always uses TCP
+# to 127.0.0.1:3306. Stripping --host/--port/--protocol entirely would force
+# the client to a unix socket (a) whose path may not exist in this image and
+# (b) whose auth path doesn't match the `test_wp@%` grant created by the
+# env-file init. TCP to 127.0.0.1 matches `%` and is always available.
+# ---------------------------------------------------------------------------
+if ! command -v mysqladmin >/dev/null 2>&1 || ! command -v mysql >/dev/null 2>&1; then
+    SHIM_DIR="${TEST_TMP_DIR}/cfwc-mysql-shim"
+    mkdir -p "$SHIM_DIR"
+    for _bin in mysqladmin mysql; do
+        cat > "$SHIM_DIR/$_bin" <<SHIM
+#!/usr/bin/env bash
+# Drop the host's --host/--port/--protocol and any -h/-P pairs from the
+# caller, then add our own that point at the in-container TCP listener.
+args=()
+while [ \$# -gt 0 ]; do
+    case "\$1" in
+        --host=*|--port=*|--protocol=*) shift ;;
+        -h?*|-P?*) shift ;;
+        --host|--port|--protocol|-h|-P) shift; [ \$# -gt 0 ] && shift ;;
+        *) args+=("\$1"); shift ;;
+    esac
+done
+exec docker compose -f "$COMPOSE_FILE" exec -T test_db $_bin \\
+    --host=127.0.0.1 --port=3306 --protocol=tcp \\
+    \${args[@]+"\${args[@]}"}
+SHIM
+        chmod +x "$SHIM_DIR/$_bin"
+    done
+    unset _bin
+    export PATH="$SHIM_DIR:$PATH"
+fi
+
+echo "============================================================"
+echo "Test environment repair"
+echo "============================================================"
+printf "   %-30s %s\n" "Plugin composer vendor"        "$([[ $REPAIR_VENDOR == 1 ]]    && echo YES || echo skip)"
+printf "   %-30s %s\n" "WC source tree"                "$([[ $REPAIR_WC == 1 ]]        && echo YES || echo skip)"
+printf "   %-30s %s\n" "WP core + test framework"      "$([[ $REPAIR_WP == 1 ]]        && echo YES || echo skip)"
+printf "   %-30s %s\n" "WP tests config DB_HOST"       "$([[ $REPAIR_WP_CONFIG == 1 ]] && echo YES || echo skip)"
+printf "   %-30s %s\n" "DB container (wipe volume)"    "$([[ $REPAIR_DB == 1 ]]        && echo YES || echo skip)"
+printf "   %-30s %s\n" "DB port wait"                  "$([[ $REPAIR_DB_PORT == 1 ]]   && echo YES || echo skip)"
+
+run_quiet() {
+    local label="$1"
+    shift
+    printf "   %-50s" "$label"
+    local log_file="${TEST_TMP_DIR}/wc-test-setup.log"
+    if "$@" > "$log_file" 2>&1; then
+        echo "✅"
+    else
+        echo "❌"
+        echo "   --- last 20 lines of $log_file ---"
+        tail -20 "$log_file"
+        return 1
+    fi
+}
+
+download() {
+    if command -v curl &>/dev/null; then
+        curl -sSL "$1" > "$2"
+    elif command -v wget &>/dev/null; then
+        wget -nv -O "$2" "$1"
+    else
+        echo "Need curl or wget to download $1" >&2
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# DB container
+# ---------------------------------------------------------------------------
+if [[ "$REPAIR_DB" == "1" ]]; then
+    echo
+    echo "▶️  Recreating DB container (wiping volume to avoid stale state)..."
+    docker compose -f "$COMPOSE_FILE" down -v --remove-orphans 2>/dev/null || true
+    docker compose -f "$COMPOSE_FILE" up -d
+fi
+
+if [[ "$REPAIR_DB" == "1" || "$REPAIR_WP" == "1" || "$REPAIR_DB_PORT" == "1" ]]; then
+    docker compose -f "$COMPOSE_FILE" up -d > /dev/null
+fi
+
+wait_for_db() {
+    local attempts=60
+    printf "   %-50s" "Waiting for database at ${TEST_DB_HOST}:${TEST_DB_PORT}..."
+    # The TCP port opens before MariaDB finishes initialising the env-file DB
+    # schema — wait for an actual ping to succeed, not just for TCP, otherwise
+    # the drop-and-recreate dance below races against MariaDB's own init.
+    for ((i=1; i<=attempts; i++)); do
+        if mysqladmin ping --user="$TEST_DB_USER" --password="$TEST_DB_PASS" \
+                --host="$TEST_DB_HOST" --port="$TEST_DB_PORT" --protocol=tcp \
+                --silent > /dev/null 2>&1; then
+            echo "✅ (after ${i}s)"
+            return 0
+        fi
+        sleep 1
+    done
+    echo "❌ (timed out after ${attempts}s)"
+    docker compose -f "$COMPOSE_FILE" logs --tail=20 test_db || true
+    return 1
+}
+
+if [[ "$REPAIR_DB" == "1" || "$REPAIR_WP" == "1" || "$REPAIR_DB_PORT" == "1" ]]; then
+    wait_for_db
+fi
+
+# ---------------------------------------------------------------------------
+# Plugin composer dependencies
+# ---------------------------------------------------------------------------
+if [[ "$REPAIR_VENDOR" == "1" ]]; then
+    echo
+    run_quiet "Installing plugin composer dependencies..." \
+        composer install --working-dir="$PROJECT_ROOT" --no-interaction --quiet
+fi
+
+# ---------------------------------------------------------------------------
+# Resolve WC_VERSION (only when we actually need it)
+# ---------------------------------------------------------------------------
+resolve_wc_version() {
+    if [ -z "$WC_VERSION" ] || [ "$WC_VERSION" = "latest" ]; then
+        WC_VERSION=$(curl -s https://api.github.com/repos/woocommerce/woocommerce/releases/latest \
+            | grep '"tag_name"' | sed 's/.*"tag_name": *"\([^"]*\)".*/\1/')
+        if [ -z "$WC_VERSION" ]; then
+            echo "Could not resolve latest WooCommerce version from GitHub API." >&2
+            return 1
+        fi
+        echo "ℹ️  Resolved latest WC version: $WC_VERSION"
+    fi
+}
+
+resolve_wp_tests_tag() {
+    if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+$ ]]; then
+        WP_TESTS_TAG="branches/$WP_VERSION"
+    elif [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        if [[ $WP_VERSION =~ [0-9]+\.[0-9]+\.[0] ]]; then
+            WP_TESTS_TAG="tags/${WP_VERSION%??}"
+        else
+            WP_TESTS_TAG="tags/$WP_VERSION"
+        fi
+    elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+        WP_TESTS_TAG="trunk"
+    else
+        download http://api.wordpress.org/core/version-check/1.7/ "${TEST_TMP_DIR}/wp-latest.json"
+        local LATEST_VERSION
+        LATEST_VERSION=$(grep -o '"version":"[^"]*"' "${TEST_TMP_DIR}/wp-latest.json" | head -1 | sed 's/"version":"//;s/"//')
+        if [ -z "$LATEST_VERSION" ]; then
+            echo "Could not resolve latest WordPress version." >&2
+            return 1
+        fi
+        WP_TESTS_TAG="tags/$LATEST_VERSION"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# WooCommerce
+# ---------------------------------------------------------------------------
+install_wc() {
+    echo
+    echo "------------------------------------------------------------"
+    echo "Installing WooCommerce $WC_VERSION → $WC_CLONE_DIR"
+    echo "------------------------------------------------------------"
+
+    rm -rf "$WC_CLONE_DIR"
+
+    run_quiet "Cloning WooCommerce..." \
+        git clone --depth=1 --branch="$WC_VERSION" https://github.com/woocommerce/woocommerce.git "$WC_CLONE_DIR" \
+        || run_quiet "Cloning WooCommerce (fallback to default branch)..." \
+            git clone --depth=1 https://github.com/woocommerce/woocommerce.git "$WC_CLONE_DIR"
+
+    if [ -f "$WC_DEVELOP_DIR/composer.json" ]; then
+        run_quiet "Running WC composer install..." \
+            composer install --working-dir="$WC_DEVELOP_DIR" --no-interaction --no-progress --quiet
+    fi
+
+    local feature_config="${WC_DEVELOP_DIR}/includes/react-admin/feature-config.php"
+    if [ ! -f "$feature_config" ] && [ -f "${WC_DEVELOP_DIR}/bin/generate-feature-config.php" ]; then
+        run_quiet "Generating WC feature-config.php..." \
+            php "${WC_DEVELOP_DIR}/bin/generate-feature-config.php"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# WordPress core + test suite
+# ---------------------------------------------------------------------------
+drop_test_db() {
+    mysqladmin drop "$TEST_DB_NAME" \
+        --user="$TEST_DB_USER" --password="$TEST_DB_PASS" \
+        --host="$TEST_DB_HOST" --port="$TEST_DB_PORT" --protocol=tcp \
+        --force 2>/dev/null || true
+}
+
+# Idempotent DB create. We create the DB ourselves (CREATE IF NOT EXISTS) and
+# then pass skip-database-creation=true to WC's install.sh — that way a stale
+# database from a prior aborted run can never wedge the repair on "database
+# exists". WC install.sh still bootstraps WP schema into the existing DB.
+ensure_test_db() {
+    mysql --user="$TEST_DB_USER" --password="$TEST_DB_PASS" \
+        --host="$TEST_DB_HOST" --port="$TEST_DB_PORT" --protocol=tcp \
+        -e "CREATE DATABASE IF NOT EXISTS \`${TEST_DB_NAME}\`;"
+}
+
+install_wp_core() {
+    if [ -d "$WP_CORE_DIR" ] && [ -f "$WP_CORE_DIR/wp-includes/version.php" ]; then
+        return
+    fi
+
+    rm -rf "$WP_CORE_DIR"
+    mkdir -p "$WP_CORE_DIR"
+
+    if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+        download https://wordpress.org/nightly-builds/wordpress-latest.zip "${TEST_TMP_DIR}/wordpress.zip"
+    elif [[ "$WP_VERSION" == 'latest' ]]; then
+        download https://wordpress.org/latest.zip "${TEST_TMP_DIR}/wordpress.zip"
+    else
+        download "https://wordpress.org/wordpress-$WP_VERSION.zip" "${TEST_TMP_DIR}/wordpress.zip"
+    fi
+
+    rm -rf "${TEST_TMP_DIR}/wordpress-extract"
+    unzip -q "${TEST_TMP_DIR}/wordpress.zip" -d "${TEST_TMP_DIR}/wordpress-extract"
+    mv "${TEST_TMP_DIR}/wordpress-extract/wordpress/"* "$WP_CORE_DIR"
+    rm -rf "${TEST_TMP_DIR}/wordpress-extract" "${TEST_TMP_DIR}/wordpress.zip"
+}
+
+install_wp_test_suite() {
+    if [ ! -d "$WP_TESTS_DIR/includes" ]; then
+        mkdir -p "$WP_TESTS_DIR"
+        svn co --quiet --ignore-externals "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"
+        svn co --quiet --ignore-externals "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/" "$WP_TESTS_DIR/data"
+    fi
+
+    # Always (re)write the config so DB_HOST tracks our compose port.
+    download "https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php" "$WP_TESTS_DIR/wp-tests-config.php"
+    local sed_in_place=( -i )
+    [[ "$(uname -s)" == 'Darwin' ]] && sed_in_place=( -i .bak )
+    sed "${sed_in_place[@]}" "s:dirname( __FILE__ ) . '/src/':'${WP_CORE_DIR%/}/':" "$WP_TESTS_DIR/wp-tests-config.php"
+    sed "${sed_in_place[@]}" "s/youremptytestdbnamehere/$TEST_DB_NAME/" "$WP_TESTS_DIR/wp-tests-config.php"
+    sed "${sed_in_place[@]}" "s/yourusernamehere/$TEST_DB_USER/" "$WP_TESTS_DIR/wp-tests-config.php"
+    sed "${sed_in_place[@]}" "s/yourpasswordhere/$TEST_DB_PASS/" "$WP_TESTS_DIR/wp-tests-config.php"
+    sed "${sed_in_place[@]}" "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR/wp-tests-config.php"
+}
+
+install_wp() {
+    echo
+    echo "------------------------------------------------------------"
+    echo "Installing WordPress $WP_VERSION → $WP_CORE_DIR"
+    echo "------------------------------------------------------------"
+
+    resolve_wp_tests_tag
+
+    install_wp_core
+    install_wp_test_suite
+
+    # Recreate the test database so install.sh's schema bootstrap is clean.
+    # Drop is best-effort (may fail if DB is missing or locked); the explicit
+    # CREATE IF NOT EXISTS that follows makes the path idempotent regardless.
+    drop_test_db
+    ensure_test_db
+
+    if [ -f "${WC_DEVELOP_DIR}/tests/bin/install.sh" ]; then
+        # Pass skip-database-creation=true (6th arg) — we just created the DB
+        # ourselves above, so WC's install.sh must not try `mysqladmin create`
+        # again (it would fail with "database exists").
+        run_quiet "Running WC install.sh (DB schema)..." \
+            bash "${WC_DEVELOP_DIR}/tests/bin/install.sh" \
+                "$TEST_DB_NAME" "$TEST_DB_USER" "$TEST_DB_PASS" "$DB_HOST" "$WP_VERSION" "true"
+    else
+        echo "❌ WC install.sh missing at ${WC_DEVELOP_DIR}/tests/bin/install.sh — cannot bootstrap WP test schema."
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# wp-tests-config.php fast repair (sed only)
+# ---------------------------------------------------------------------------
+repair_wp_config() {
+    local cfg="${WP_TESTS_DIR}/wp-tests-config.php"
+    if [ ! -f "$cfg" ]; then
+        echo "❌ $cfg not found — escalating to full WP repair." >&2
+        REPAIR_WP=1
+        return 0
+    fi
+    echo
+    printf "   %-50s" "Rewriting wp-tests-config.php DB_HOST..."
+    local sed_in_place=( -i )
+    [[ "$(uname -s)" == 'Darwin' ]] && sed_in_place=( -i .bak )
+    sed "${sed_in_place[@]}" -E \
+        "s|define\(\s*'DB_HOST'\s*,\s*'[^']*'\s*\)|define( 'DB_HOST', '${DB_HOST}' )|" "$cfg"
+    if grep -qE "define\(\s*'DB_HOST'\s*,\s*'${TEST_DB_HOST}:${TEST_DB_PORT}'\s*\)" "$cfg"; then
+        echo "✅ → ${DB_HOST}"
+    else
+        echo "❌ — sed did not rewrite the line; escalating to full WP repair."
+        REPAIR_WP=1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Component dispatch (cheapest first)
+# ---------------------------------------------------------------------------
+[[ "$REPAIR_WP_CONFIG" == "1" ]] && repair_wp_config
+[[ "$REPAIR_WC" == "1" ]] && { resolve_wc_version; install_wc; }
+[[ "$REPAIR_WP" == "1" ]] && install_wp
+
+echo
+echo "🟢 Test environment repair complete."

--- a/tests/bin/run-tests.sh
+++ b/tests/bin/run-tests.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# run-tests.sh
+#
+# Orchestrates the full test run:
+#   1. Health-check the test environment, repairing only the components that
+#      fail their probe (cheapest = a single sed on wp-tests-config.php when
+#      another plugin's setup wrote a different DB port into shared /tmp).
+#   2. Run PHPUnit.
+#
+# Usage:
+#   bash tests/bin/run-tests.sh
+#   composer test
+#   composer test -- --filter=test_has_cycle_membership
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/test-config.sh"
+
+# ---------------------------------------------------------------------------
+# 1. Health-check + granular repair
+# ---------------------------------------------------------------------------
+bash "$SCRIPT_DIR/check-test-env.sh"
+
+# ---------------------------------------------------------------------------
+# 2. Run PHPUnit (pass any extra args through, e.g. --filter)
+# ---------------------------------------------------------------------------
+echo "==> Running PHPUnit..."
+# WC's bootstrap emits PHP notices/warnings to stderr that bury PHPUnit output.
+# Filter only those known-noisy lines; pass everything else through so real
+# PHPUnit errors (fatal errors, segfaults) remain visible.
+"$PROJECT_ROOT/vendor/bin/phpunit" "$@" 2>&1 \
+    | grep -Ev "^(PHP Deprecated|PHP Notice|PHP Warning|Xdebug)" \
+    || true

--- a/tests/bin/test-config.sh
+++ b/tests/bin/test-config.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# test-config.sh
+#
+# Single source of truth for test environment configuration.
+# Sourced by run-tests.sh, install-wc-tests.sh and check-test-env.sh.
+#
+# DB credentials come from tests/test.env (the same file mariadb itself reads
+# via `env_file:` in tests/docker-compose.yml — defaults can never drift from
+# what the container accepts). The DB port is parsed from the published port in
+# tests/docker-compose.yml ("4416:3306" → 4416).
+#
+# /tmp paths are intentionally shared across woocommerce extension plugins
+# (USPS, ShipStation, Customs Fees, etc.) so /tmp/wordpress, /tmp/wordpress-tests-lib
+# and /tmp/woocommerce only need to be downloaded once. The only file that's truly
+# plugin-specific is wp-tests-config.php (it bakes in DB_HOST including the
+# port) — check-test-env.sh detects drift on that file and triggers a sed-only
+# fast repair.
+
+__tc_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+__tc_env_file="${__tc_dir}/test.env"
+__tc_compose_file="${__tc_dir}/docker-compose.yml"
+
+if [[ -f "$__tc_env_file" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    source "$__tc_env_file"
+    set +a
+fi
+
+TEST_DB_NAME="${MYSQL_DATABASE:-test_wp}"
+TEST_DB_USER="${MYSQL_USER:-test_wp}"
+TEST_DB_PASS="${MYSQL_PASSWORD:-test_wp}"
+TEST_DB_HOST="127.0.0.1"
+TEST_DB_PORT="$(grep -oE '[0-9]+:3306' "$__tc_compose_file" 2>/dev/null | head -1 | cut -d: -f1)"
+TEST_DB_PORT="${TEST_DB_PORT:-4416}"
+
+# Shared /tmp paths (intentionally not plugin-specific — see header).
+TEST_TMP_DIR="${TMPDIR:-/tmp}"
+TEST_TMP_DIR="${TEST_TMP_DIR%/}"
+export WP_CORE_DIR="${WP_CORE_DIR:-${TEST_TMP_DIR}/wordpress}"
+export WP_TESTS_DIR="${WP_TESTS_DIR:-${TEST_TMP_DIR}/wordpress-tests-lib}"
+export WC_CLONE_DIR="${WC_CLONE_DIR:-${TEST_TMP_DIR}/woocommerce}"
+export WC_DEVELOP_DIR="${WC_DEVELOP_DIR:-${WC_CLONE_DIR}/plugins/woocommerce}"
+
+export TEST_DB_NAME TEST_DB_USER TEST_DB_PASS TEST_DB_HOST TEST_DB_PORT
+
+unset __tc_dir __tc_env_file __tc_compose_file

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * PHPUnit bootstrap for Customs Fees for WooCommerce unit tests.
+ *
+ * Mirrors the ShipStation extension setup: it loads WooCommerce's legacy test
+ * bootstrap (which boots WordPress + WooCommerce against the throwaway test DB),
+ * then the plugin under test. Unlike ShipStation, the plugin has no file-scope
+ * side effects, so the whole plugin is loaded normally — its loader is gated
+ * behind is_woocommerce_active(), which reads the active_plugins option, so we
+ * mark WooCommerce active for the run via the active_plugins filter.
+ *
+ * Run with:  composer test   (which calls tests/bin/run-tests.sh)
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+if ( false !== getenv( 'WC_DEVELOP_DIR' ) ) {
+	$wc_root = getenv( 'WC_DEVELOP_DIR' );
+} elseif ( file_exists( '/tmp/woocommerce/plugins/woocommerce/tests/legacy/bootstrap.php' ) ) {
+	$wc_root = '/tmp/woocommerce/plugins/woocommerce';
+} else {
+	exit( 'Could not find WC test root. Have you run tests/bin/install-wc-tests.sh?' );
+}
+
+$env_wp_tests_dir = getenv( 'WP_TESTS_DIR' );
+$wp_tests_dir     = $env_wp_tests_dir ? $env_wp_tests_dir : rtrim( sys_get_temp_dir(), '/\\' ) . '/wordpress-tests-lib';
+
+if ( ! file_exists( $wp_tests_dir . '/includes/functions.php' ) ) {
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- fatal bootstrap error, not web output.
+	exit( "Could not find $wp_tests_dir/includes/functions.php. Run tests/bin/install-wc-tests.sh first." . PHP_EOL );
+}
+
+require_once $wp_tests_dir . '/includes/functions.php';
+
+if ( ! defined( 'WC_UNIT_TESTING' ) ) {
+	define( 'WC_UNIT_TESTING', true );
+}
+
+/**
+ * Load the plugin under test once WordPress reaches muplugins_loaded.
+ *
+ * WooCommerce itself is loaded by WC's legacy bootstrap; this only needs to
+ * pull in the plugin's main file, which registers the plugins_loaded init hook.
+ */
+function _cfwc_manually_load_plugin() {
+	require dirname( __DIR__ ) . '/customs-fees-for-woocommerce.php';
+}
+tests_add_filter( 'muplugins_loaded', '_cfwc_manually_load_plugin' );
+
+/**
+ * Mark WooCommerce active so the plugin's is_woocommerce_active() gate passes.
+ *
+ * The test database has an empty active_plugins option, so without this the
+ * plugin's loader never runs and the CFWC_* classes never load.
+ *
+ * @param mixed $plugins Active plugins list.
+ * @return array Active plugins including WooCommerce.
+ */
+function _cfwc_force_woocommerce_active( $plugins ) {
+	$plugins = (array) $plugins;
+	if ( ! in_array( 'woocommerce/woocommerce.php', $plugins, true ) ) {
+		$plugins[] = 'woocommerce/woocommerce.php';
+	}
+	return $plugins;
+}
+tests_add_filter( 'active_plugins', '_cfwc_force_woocommerce_active' );
+
+// Load WC's legacy bootstrap (boots WordPress + WooCommerce).
+require $wc_root . '/tests/legacy/bootstrap.php';
+
+// Composer autoloader for the PSR-4 test namespace (WooCommerce\CustomsFees\Tests\).
+require_once dirname( __DIR__ ) . '/vendor/autoload.php';

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,0 +1,16 @@
+name: cfwc_tests
+
+volumes:
+    dockerdirectory:
+
+services:
+    test_db:
+        image: mariadb:10.11
+        env_file:
+            - test.env
+        ports:
+            - 4416:3306
+    test_adminer:
+        image: adminer
+        ports:
+            - "8062:8080"

--- a/tests/test.env
+++ b/tests/test.env
@@ -1,0 +1,5 @@
+# Database
+MYSQL_ROOT_PASSWORD=test_wp
+MYSQL_DATABASE=test_wp
+MYSQL_USER=test_wp
+MYSQL_PASSWORD=test_wp


### PR DESCRIPTION
### Description

The shipped Canada, Australia, and New Zealand customs presets were calculating import tax on the wrong base. These jurisdictions require **different valuation bases for duty vs. import tax within the same country** (e.g. Canada: duty on FOB, GST on CIF + Duty), but the plugin only exposed a single *global* FOB/CIF setting — so no configuration produced a compliant result. Merchants using these presets in good faith were under- or over-collecting tax at checkout.

This PR introduces **per-rule valuation** and **compound bases** so a single country preset can mix valuation methods and stack rules on top of other rules' outputs (e.g. tax base = CIF + Duty). The calculator is re-architected as a round-based engine with cycle detection so dependent rules resolve in the correct order. Existing presets (CA/AU/NZ/UK/EU) are updated to declare the correct per-rule valuation and dependencies, and a one-time migration assigns stable `rule_id`s and sane defaults to existing user rules.

### Changes in this PR

- Calculator rewritten as a round-based engine that resolves rule dependencies via `base_includes` and detects cycles before evaluating (`includes/class-cfwc-calculator.php`).
- Per-rule `valuation` (`fob` / `cif` / inherit-global) and `base_includes` (list of dependent `rule_id`s) added to the rule schema, with sanitization, migration, and CSV export/import support.
- Stable `rule_id`s introduced and preserved through the rule matcher, AJAX save flow, CSV import, and preset append (preset IDs are suffixed on append to prevent collisions).
- Admin UI: new **Valuation** and **Depends on** columns in the rules table, populated select options in `admin.js`, dependency error notice, and i18n strings.
- Presets updated (CA GST, AU GST, NZ GST, UK VAT, EU VAT) to use correct per-rule valuation and `base_includes` so import tax compounds on duty per CBSA / ABF / HMRC / EU rules.
- One-time migration hook for v1.2.0 gated on a dedicated option (not plugin version) and triggered on `init` so the frontend cart sees migrated data; rules transient and calculator cache are explicitly cleared on save.
- CSV import tolerates column-count drift from older exports.
- Documentation updated: `docs/CIF.md` covers per-rule valuation and compound bases; `changelog.txt` / `readme.txt` updated.

### Test Instructions

1. Checkout this branch locally and run `composer install && pnpm install && pnpm build:dev`.
2. Activate the plugin on a fresh WC store and go to **WooCommerce → Settings → Tax → Customs & Import Fees**.
3. Leave **Customs Valuation Method** on its default (FOB). Import the **Canada GST & Duty** preset.
4. Create a simple product priced at **$100** with any origin.
5. Add to cart, set the shipping destination to **Canada**, and add a shipping method totaling **$20**.
6. Go to checkout and inspect the customs fee breakdown. Expected:
   - **Canada Duty (Import):** `8% × $100 = $8.00` (FOB base)
   - **Canada GST (Import):** `5% × ($100 + $20 + $8) = $6.40` (CIF + Duty base)
7. Repeat with the **Australia GST** and **New Zealand GST** presets — import tax should compound on duty + freight, matching ABF/NZ rules.
8. Repeat with **UK VAT** and **EU VAT** — both duty and VAT use CIF; VAT should compound on duty.
9. Open **Rules** table and confirm the new **Valuation** and **Depends on** columns render and are editable. Try creating a rule that depends on itself — the dependency error notice should appear.
10. Export rules to CSV, re-import, and verify `valuation` / `base_includes` / `rule_id` are preserved. Try importing an older CSV (fewer columns) — it should still import without fatal.
11. On a site with pre-existing rules from v1.1.x, deploy this branch and load any wp-admin page; confirm the migration runs once (each rule gains a stable `rule_id` and default valuation), and that the frontend cart calculates fees correctly without a second page load.
12. Run **WooCommerce → Status → Logs** and confirm no new warnings/notices in `cfwc-*` logs during the flows above.

### Things to check

- [x] Are all texts internationalized?
- [x] Has a cache been added?
- [x] Are the hooks/filters called only when necessary?
- [x] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications?
