### PR TITLE
Fix CFWC_VERSION 1.1.7  - already released

### DIFF
--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'CFWC_VERSION', '1.1.8' );
+define( 'CFWC_VERSION', '1.1.8' ); // WRCS: DEFINED_VERSION.
 define( 'CFWC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'CFWC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CFWC_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'CFWC_VERSION', '1.1.7' );
+define( 'CFWC_VERSION', '1.1.8' );
 define( 'CFWC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'CFWC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CFWC_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugin constants.
-define( 'CFWC_VERSION', '1.1.5' );
+define( 'CFWC_VERSION', '1.1.7' );
 define( 'CFWC_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'CFWC_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'CFWC_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );

--- a/readme.txt
+++ b/readme.txt
@@ -192,10 +192,10 @@ Yes, through:
 
 == Changelog ==
 
-= 1.1.7 - 2026-xx-xx =
+= 1.1.7 - 2026-04-13 =
 * Tweak - WooCommerce 10.7 Compatibility.
 
-= 1.1.6 - 2026-xx-xx =
+= 1.1.6 - 2026-03-31 =
 * Tweak - WooCommerce 10.6 Compatibility.
 
 = 1.1.5 - 2026-02-04 =

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Requires PHP: 7.4
 Requires Plugins: woocommerce
 WC requires at least: 10.6
 WC tested up to: 10.8
-Stable tag: 1.1.5
+Stable tag: 1.1.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
### Description

The `CFWC_VERSION` constant and several version references were out of sync with the already-released 1.1.7 version.

### Things to check

- [ ] Are all texts internationalized?
- [ ] Has a cache been added?
- [ ] Are the hooks/filters called only when necessary?
- [ ] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications?