### PR TITLE
Tweak - Declare WordPress 7.0 Compatibility

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -186,6 +186,36 @@ span[aria-labelledby="select2-_cfwc_country_of_origin-container"] {
 	max-width: 250px !important;
 }
 
+/*
+ * Select2 height normalization for WP 7.0+.
+ */
+body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single {
+	height: 40px;
+}
+
+body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single .select2-selection__rendered {
+	line-height: 38px;
+}
+
+body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--single .select2-selection__arrow {
+	height: 38px;
+}
+
+body[class*="branch-7"] .cfwc-select2-field + .select2-container .select2-selection--multiple {
+	min-height: 40px;
+}
+
+body[class*="branch-7"] .cfwc-rule-editing input[type="text"],
+body[class*="branch-7"] .cfwc-rule-editing input[type="number"],
+body[class*="branch-7"] .cfwc-rule-editing select:not(.select2-hidden-accessible) {
+	min-height: 40px;
+}
+
+/* From / To country selects stack vertically — add a 5px gap to the visible Select2 widget after the From field. */
+.cfwc-country-select[data-field="from_country"] + .select2-container {
+	margin-bottom: 5px;
+}
+
 /* WooCommerce Snackbar Container - Align with Save button */
 .components-snackbar-list {
 	position: fixed;
@@ -360,6 +390,20 @@ span[aria-labelledby="select2-_cfwc_country_of_origin-container"] {
 	font-size: 13px;
 }
 
+/* WP 7.0+ override for the rules-editing row Select2. */
+body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single {
+	height: 40px;
+	line-height: 38px;
+}
+
+body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single .select2-selection__rendered {
+	line-height: 38px;
+}
+
+body[class*="branch-7"] .cfwc-rule-editing .select2-container--default .select2-selection--single .select2-selection__arrow {
+	height: 38px;
+}
+
 /* Prevent Select2 dropdown from causing overflow */
 .select2-container--open .select2-dropdown {
 	min-width: 200px !important;
@@ -385,6 +429,11 @@ span[aria-labelledby="select2-_cfwc_country_of_origin-container"] {
 /* Prevent layout shift when switching modes */
 .cfwc-rules-table tbody tr {
 	height: 38px; /* Fixed height to prevent jumping */
+}
+
+/* WP 7.0+ row height to accommodate 40px form fields. */
+body[class*="branch-7"] .cfwc-rules-table tbody tr {
+	height: 50px;
 }
 
 .cfwc-rule-editing {
@@ -563,6 +612,20 @@ span[aria-labelledby="select2-_cfwc_country_of_origin-container"] {
 	.select2-selection--single
 	.select2-selection__arrow {
 	height: 30px;
+}
+
+/* WP 7.0+ overrides for the preset-loader Select2. */
+body[class*="branch-7"] .cfwc-preset-loader .select2-container .select2-selection--single {
+	height: 40px;
+	line-height: 38px;
+}
+
+body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2-selection--single .select2-selection__rendered {
+	line-height: 38px;
+}
+
+body[class*="branch-7"] .cfwc-preset-loader .select2-container--default .select2-selection--single .select2-selection__arrow {
+	height: 38px;
 }
 
 /* Mobile Responsive Styles */

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -752,19 +752,16 @@
       // Countries column (From and To).
       newRowHtml += "<td>";
       newRowHtml +=
-        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select" data-field="from_country" data-placeholder="' +
+        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="from_country" data-placeholder="' +
         (strings.from_country || "From (any)") +
-        '" style="width: 47%;">';
+        '" style="width: 100%;">';
       newRowHtml +=
         '<option value="">Any Origin</option>' + getCountryOptions("");
       newRowHtml += "</select>";
-      // Add spacing between dropdowns.
       newRowHtml +=
-        '<span style="display: inline-block; width: 10px;">&nbsp;</span>';
-      newRowHtml +=
-        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select" data-field="to_country" data-placeholder="' +
+        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="to_country" data-placeholder="' +
         (strings.to_country || "To (any)") +
-        '" style="width: 47%;">';
+        '" style="width: 100%;">';
       newRowHtml +=
         '<option value="">Any Destination</option>' + getCountryOptions("");
       newRowHtml += "</select></td>";
@@ -780,7 +777,7 @@
       newRowHtml += "</select>";
       // Category selector (hidden by default - only show for category/combined).
       newRowHtml +=
-        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-category-select wc-enhanced-select" data-field="category_ids" multiple="multiple" style="width: 100%; display: none; margin-bottom: 5px;" data-placeholder="Select categories...">';
+        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-category-select wc-enhanced-select cfwc-select2-field" data-field="category_ids" multiple="multiple" style="width: 100%; display: none; margin-bottom: 5px;" data-placeholder="Select categories...">';
       if (cfwc_admin.categories) {
         $.each(cfwc_admin.categories, function (id, name) {
           newRowHtml += '<option value="' + id + '">' + name + "</option>";
@@ -936,22 +933,19 @@
       // Countries column (From and To).
       editRowHtml += "<td>";
       editRowHtml +=
-        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select" data-field="from_country" data-placeholder="' +
+        '<select name="cfwc_rule_from_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="from_country" data-placeholder="' +
         (strings.from_country || "From (any)") +
-        '" style="width: 47%;">';
+        '" style="width: 100%;">';
       editRowHtml +=
         '<option value="">Any Origin</option>' +
         getCountryOptions(
           rule.from_country || rule.origin_country || rule.country || ""
         );
       editRowHtml += "</select>";
-      // Add spacing between dropdowns.
       editRowHtml +=
-        '<span style="display: inline-block; width: 10px;">&nbsp;</span>';
-      editRowHtml +=
-        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select" data-field="to_country" data-placeholder="' +
+        '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="to_country" data-placeholder="' +
         (strings.to_country || "To (any)") +
-        '" style="width: 47%;">';
+        '" style="width: 100%;">';
       editRowHtml +=
         '<option value="">Any Destination</option>' +
         getCountryOptions(rule.to_country || rule.country || "");
@@ -987,7 +981,7 @@
           ? "Select categories (optional)"
           : "Select categories...";
       editRowHtml +=
-        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-category-select wc-enhanced-select" data-field="category_ids" multiple="multiple" style="width: 100%; margin-bottom: 5px;' +
+        '<select name="cfwc_rule_categories" class="cfwc-rule-field cfwc-category-select wc-enhanced-select cfwc-select2-field" data-field="category_ids" multiple="multiple" style="width: 100%; margin-bottom: 5px;' +
         (showCategories ? "" : " display: none;") +
         '" data-placeholder="' +
         categoryPlaceholder +

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Customs Fees for WooCommerce Changelog ***
 
 2026-xx-xx - version 1.1.8
+* Tweak - WordPress 7.0 Compatibility.
 * Tweak - WooCommerce 10.8 Compatibility.
 
 2026-04-13 - version 1.1.7

--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -11,8 +11,8 @@
  * Text Domain:       customs-fees-for-woocommerce
  * Domain Path:       /languages
  * Requires Plugins:  woocommerce
- * Requires at least: 6.8
- * Tested up to:      6.9
+ * Requires at least: 6.9
+ * Tested up to:      7.0
  * Requires PHP:      7.4
  * WC requires at least: 10.6
  * WC tested up to:   10.8

--- a/includes/admin/class-cfwc-admin.php
+++ b/includes/admin/class-cfwc-admin.php
@@ -231,7 +231,7 @@ class CFWC_Admin {
 				'description'       => __( 'Select the country where this product was manufactured. This determines which customs rules apply.', 'customs-fees-for-woocommerce' ),
 				'options'           => array( '' => __( 'Select a country', 'customs-fees-for-woocommerce' ) ) + $countries,
 				'value'             => $origin_value,
-				'class'             => 'wc-enhanced-select',
+				'class'             => 'wc-enhanced-select cfwc-select2-field',
 				'custom_attributes' => array(
 					'data-placeholder' => __( 'Select a country', 'customs-fees-for-woocommerce' ),
 				),

--- a/includes/admin/views/rules-section.php
+++ b/includes/admin/views/rules-section.php
@@ -97,7 +97,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					</label>
 				</th>
 				<td class="forminp">
-					<select id="cfwc_default_origin_select" name="cfwc_default_origin_select" class="wc-enhanced-select" style="width: 350px; max-width: 50%;">
+					<select id="cfwc_default_origin_select" name="cfwc_default_origin_select" class="wc-enhanced-select cfwc-select2-field" style="width: 350px; max-width: 50%;">
 						<option value="store" <?php selected( $selected_origin, 'store' ); ?>>
 							<?php
 							printf(
@@ -565,7 +565,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<h3><?php esc_html_e( 'Quick Start with Presets', 'customs-fees-for-woocommerce' ); ?></h3>
 		<p><?php esc_html_e( 'Load presets to quickly configure common import scenarios:', 'customs-fees-for-woocommerce' ); ?></p>
 		
-		<select id="cfwc-preset-select" class="wc-enhanced-select" style="width: 280px; max-width: 100%;">
+		<select id="cfwc-preset-select" class="wc-enhanced-select cfwc-select2-field" style="width: 280px; max-width: 100%;">
 			<option value=""><?php esc_html_e( '-- Select a preset --', 'customs-fees-for-woocommerce' ); ?></option>
 			<?php if ( ! empty( $templates ) ) : ?>
 				<?php foreach ( $templates as $template_id => $template ) : ?>

--- a/includes/class-cfwc-products-variation-support.php
+++ b/includes/class-cfwc-products-variation-support.php
@@ -90,9 +90,9 @@ class CFWC_Products_Variation_Support {
 					);
 					?>
 				</label>
-				<select id="cfwc_country_of_origin_<?php echo esc_attr( $loop ); ?>" 
-						name="cfwc_country_of_origin[<?php echo esc_attr( $loop ); ?>]" 
-						class="wc-enhanced-select">
+				<select id="cfwc_country_of_origin_<?php echo esc_attr( $loop ); ?>"
+						name="cfwc_country_of_origin[<?php echo esc_attr( $loop ); ?>]"
+						class="wc-enhanced-select cfwc-select2-field">
 					<option value=""><?php esc_html_e( 'Use parent product', 'customs-fees-for-woocommerce' ); ?></option>
 					<?php
 					foreach ( WC()->countries->get_countries() as $code => $country ) {

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Customs Fees for WooCommerce ===
 Contributors: woocommerce
 Tags: woocommerce, customs, import-fees, international-shipping, tariffs
-Requires at least: 6.8
-Tested up to: 6.9
+Requires at least: 6.9
+Tested up to: 7.0
 Requires PHP: 7.4
 Requires Plugins: woocommerce
 WC requires at least: 10.6
@@ -193,6 +193,7 @@ Yes, through:
 == Changelog ==
 
 = 1.1.8 - 2026-xx-xx =
+* Tweak - WordPress 7.0 Compatibility.
 * Tweak - WooCommerce 10.8 Compatibility.
 
 = 1.1.7 - 2026-xx-xx =

--- a/readme.txt
+++ b/readme.txt
@@ -192,8 +192,10 @@ Yes, through:
 
 == Changelog ==
 
-= 1.1.8 - 2026-xx-xx =
+= 1.1.9 - 2026-xx-xx =
 * Tweak - WordPress 7.0 Compatibility.
+
+= 1.1.8 - 2026-05-20 =
 * Tweak - WooCommerce 10.8 Compatibility.
 
 = 1.1.7 - 2026-xx-xx =


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changes proposed in this Pull Request:

Declares compatibility with WordPress 7.0:
- Bumps `Tested up to` from 6.9 to 7.0
- Bumps `Requires at least` from 6.8 to 6.9
- Appends a `WordPress 7.0 Compatibility` entry to the in-progress 4.0.3 changelog block

Closes CUSFEES-16.

### How to test the changes in this Pull Request:

1. Check out this branch on your local environment.
2. On a site running WordPress 7.0, activate the plugin and confirm the plugin loads with no errors/warnings.
3. Smoke test core flows (rate calculation in cart/checkout, settings page) to confirm no regressions.
4. In the plugin header, verify `Tested up to: 7.0` and `Requires at least: 6.9`.
5. Verify the new `* Tweak - WordPress 7.0 Compatibility.` line appears under the `4.0.3` entry in `changelog.txt`.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Tweak - WordPress 7.0 Compatibility.