### PR TITLE
Fix/issue CUSFEES-19 - Upgrade PHPStan to level 2 and resolve empty() false positive in CSV   import  

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,12 @@
 *** Customs Fees for WooCommerce Changelog ***
 
+2026-xx-xx - version 1.2.1
+* Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
+
 2026-06-01 - version 1.2.0
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
-* Fix - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
-* Fix - Show confirmation dialog when leaving page or saving settings with an unsaved rule open.
+* Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
+* Fix    - Show confirmation dialog when leaving page or saving settings with an unsaved rule open.
 * Update - Built-in presets for Canada, Australia, New Zealand, UK, and EU now use correct duty vs. import tax valuation bases.
 * Dev    - `cfwc_customs_value` filter now passes the matching rule as a 5th argument; existing 4-argument callbacks remain backwards-compatible.
 

--- a/composer.json
+++ b/composer.json
@@ -47,6 +47,9 @@
         }
     },
     "scripts": {
+        "phpstan": [
+            "./vendor/bin/phpstan analyse --level=2"
+        ],
         "test": [
             "bash tests/bin/run-tests.sh"
         ]

--- a/includes/admin/class-cfwc-ajax.php
+++ b/includes/admin/class-cfwc-ajax.php
@@ -409,11 +409,6 @@ class CFWC_Ajax {
 			// Add escape parameter (backslash) for PHP 8.4+ compatibility.
 			$data = str_getcsv( $line, ',', '"', '\\' );
 
-			// Skip rows that have no data at all.
-			if ( empty( $data ) ) {
-				continue;
-			}
-
 			// Tolerate row width drift: pad short rows (Excel/Sheets often
 			// strips trailing empty columns on save) and truncate long ones
 			// so the header_map lookups stay in bounds.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
 	# - vendor/szepeviktor/phpstan-wordpress/extension.neon
 
 parameters:
-	level: 0
+	level: 2
 	paths:
 		- .
 		- customs-fees-for-woocommerce.php
@@ -27,5 +27,5 @@ parameters:
 	
 	# Common WordPress-specific ignores
 	ignoreErrors:
-		# Ignore WooCommerce internal class not found (HPOS related)
-		- '#Class Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\CustomOrdersTableController not found#'
+		# Ignore WooCommerce internal class not found (HPOS related) -- absent from stubs
+		- '#Automattic\\WooCommerce\\Internal\\DataStores\\Orders\\CustomOrdersTableController#'

--- a/readme.txt
+++ b/readme.txt
@@ -192,14 +192,16 @@ Yes, through:
 
 == Changelog ==
 
-= 1.2.0 - 2026-xx-xx =
+= 1.2.1 - 2026-xx-xx =
+* Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
+
+= 1.2.0 - 2026-06-01 =
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
-* Fix - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
-* Fix - Show confirmation dialog when leaving page or saving settings with an unsaved rule open.
+* Fix    - Show confirmation dialog when leaving page or saving settings with an unsaved rule open.
 * Update - Built-in presets for Canada, Australia, New Zealand, UK, and EU now use correct duty vs. import tax valuation bases.
 * Dev    - `cfwc_customs_value` filter now passes the matching rule as a 5th argument; existing 4-argument callbacks remain backwards-compatible.
 
-= 1.1.9 - 2026-xx-xx =
+= 1.1.9 - 2026-05-20 =
 * Tweak - WordPress 7.0 Compatibility.
 
 = 1.1.8 - 2026-05-20 =


### PR DESCRIPTION
* Fix [CUSFEES-19](https://linear.app/a8c/issue/CUSFEES-19/phpstan-test-error)

### Description

The QIT PHPStan test (level 2) was failing due to an unreachable `empty()` check on the return value of `str_getcsv()`. Since `str_getcsv()` always returns an array, PHPStan correctly flags `empty($data)` as always false. The check was also redundant — empty lines are already skipped earlier in the same loop.

This PR removes the dead check and upgrades the local PHPStan config from level 0 to level 2 so issues at this level are caught locally before reaching QIT.

### Changes in this PR

- Remove unreachable `empty($data)` check after `str_getcsv()` in `class-cfwc-ajax.php`
- Bump PHPStan analysis level from 0 to 2 in `phpstan.neon`
- Widen the HPOS class ignore pattern to cover both "class not found" and "method on unknown class" errors for `CustomOrdersTableController` (absent from WooCommerce stubs)

### Test Instructions

1. Checkout this branch locally.
2. Run `composer install`.
3. Run `php -d memory_limit=2G vendor/bin/phpstan analyse --memory-limit=2G --no-progress` and confirm the output is `No errors`.

### Things to check

- [ ] Are all texts internationalized?
- [ ] Has a cache been added?
- [ ] Are the hooks/filters called only when necessary?
- [ ] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications?
