### PR TITLE
[CUSFEES-18] Tweak - WooCommerce 10.9 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2026-xx-xx - version 1.2.1
 * Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
+* Tweak  - WooCommerce 10.9 Compatibility.
 
 2026-06-01 - version 1.2.0
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.

--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -14,8 +14,8 @@
  * Requires at least: 6.9
  * Tested up to:      7.0
  * Requires PHP:      7.4
- * WC requires at least: 10.6
- * WC tested up to:   10.8
+ * WC requires at least: 10.7
+ * WC tested up to:   10.9
  * Woo: 18734005702334:78cd9350327fbb9496bc3fbfd7335b53
  *
  * @package CustomsFeesForWooCommerce

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 7.4
 Requires Plugins: woocommerce
-WC requires at least: 10.6
-WC tested up to: 10.8
+WC requires at least: 10.7
+WC tested up to: 10.9
 Stable tag: 1.1.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -194,6 +194,7 @@ Yes, through:
 
 = 1.2.1 - 2026-xx-xx =
 * Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
+* Tweak  - WooCommerce 10.9 Compatibility.
 
 = 1.2.0 - 2026-06-01 =
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.


### PR DESCRIPTION
Bumps WooCommerce compatibility headers for the WooCommerce 10.9 release.

- `WC requires at least`: 10.6 → 10.7 (plugin header and readme.txt)
- `WC tested up to`: 10.8 → 10.9 (plugin header and readme.txt)
- Added WooCommerce 10.9 compatibility note to the pending version 1.2.1 changelog entry (changelog.txt and readme.txt).

Part of CUSFEES-18.
https://linear.app/a8c/issue/CUSFEES-18/ensure-woocommerce-109-compatibility-customs-fees-for-woocommerce