### PR TITLE
CUSFEES-20: Recalibrate China to US preset to post-IEEPA tariff rates

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ GNU General Public License for more details.
 
 ## Changelog
 
+### Version 1.2.1
+
+- Updated the China to US tariff preset rates to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
+
 ### Version 1.2.0
 
 - Fixed rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.

--- a/README.md
+++ b/README.md
@@ -344,7 +344,7 @@ GNU General Public License for more details.
 
 ## Changelog
 
-### Version 1.2.1
+### Version 1.3.0
 
 - Updated the China to US tariff preset rates to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,11 @@
 *** Customs Fees for WooCommerce Changelog ***
 
+2026-xx-xx - version 1.3.0
+* Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
+
 2026-06-22 - version 1.2.1
 * Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
 * Tweak  - WooCommerce 10.9 Compatibility.
-* Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
 
 2026-06-01 - version 1.2.0
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2026-06-22 - version 1.2.1
 * Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
 * Tweak  - WooCommerce 10.9 Compatibility.
+* Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
 
 2026-06-01 - version 1.2.0
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.

--- a/includes/class-cfwc-templates.php
+++ b/includes/class-cfwc-templates.php
@@ -78,7 +78,7 @@ class CFWC_Templates {
 
 			'china_to_us'              => array(
 				'name'        => __( 'China to US Import Tariffs (2026)', 'customs-fees-for-woocommerce' ),
-				'description' => __( '⚠️ COMPLETE PRESET: Clear existing rules before applying! This preset includes China→US tariffs (Section 301 and Section 232). Rates reflect the durable regime after the IEEPA tariffs were struck down in February 2026. No additional US import rules needed.', 'customs-fees-for-woocommerce' ),
+				'description' => __( '⚠️ COMPLETE PRESET: Clear existing rules before applying! Applies representative China→US tariffs for the durable regime after the IEEPA tariffs were struck down in February 2026 (MFN base + Section 301, plus Section 232 where applicable). Rates are per-category representatives, not exact HTS duties. Excludes the temporary Section 122 import surcharge in effect through 24 July 2026. Confirm exact duties for your products.', 'customs-fees-for-woocommerce' ),
 				'rules'       => array(
 					// Apparel/Clothing - ~24% (MFN base ~16.5% + Section 301 List 4A 7.5%).
 					array(
@@ -122,17 +122,17 @@ class CFWC_Templates {
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Electric Vehicles - 100%.
+					// Electric Vehicles - 102.5% (MFN 2.5% + Section 301 100%).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '8703.80*',  // Electric vehicles.
 						'type'            => 'percentage',
-						'rate'            => 100,  // 100% tariff on EVs.
+						'rate'            => 102.5,  // MFN 2.5% + Section 301 100%. Excludes Section 232 auto 25% (a complete vehicle would total 127.5%).
 						'priority'        => 40,  // Highest priority.
 						'stacking_mode'   => 'exclusive',
-						'label'           => __( 'China Electric Vehicles (100%)', 'customs-fees-for-woocommerce' ),
+						'label'           => __( 'China Electric Vehicles (Section 301)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
@@ -150,28 +150,30 @@ class CFWC_Templates {
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Steel Products - ~78% (MFN ~3% + Section 301 25% + Section 232 50%).
+					// Steel Products - ~78% high-end for PRIMARY steel (Annex I-A, Section 232 50%): MFN ~3% + Section 301 25% + Section 232 50%.
+					// Most finished Chapter 73 articles are Annex I-B derivatives at Section 232 25% (~53% total). Kept high as a conservative representative.
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '72*,73*',  // Steel & Iron Products.
 						'type'            => 'percentage',
-						'rate'            => 78,  // Section 301 plus Section 232 (50% since June 2025).
+						'rate'            => 78,  // Primary metal (Annex I-A) high-end; finished Annex I-B derivatives are ~53%.
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
 						'label'           => __( 'China Steel (Section 301 + 232)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Aluminum Products - ~78% (MFN ~3% + Section 301 25% + Section 232 50%).
+					// Aluminum Products - ~78% high-end for PRIMARY aluminum (Annex I-A, Section 232 50%): MFN ~3% + Section 301 25% + Section 232 50%.
+					// Most finished aluminum articles are Annex I-B derivatives at Section 232 25% (~53% total). Kept high as a conservative representative.
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '76*',  // Aluminum Products.
 						'type'            => 'percentage',
-						'rate'            => 78,  // Section 301 plus Section 232 (50% since June 2025).
+						'rate'            => 78,  // Primary metal (Annex I-A) high-end; finished Annex I-B derivatives are ~53%.
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
 						'label'           => __( 'China Aluminum (Section 301 + 232)', 'customs-fees-for-woocommerce' ),
@@ -206,28 +208,30 @@ class CFWC_Templates {
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Consumer Appliances (steel-derivative) - ~76% (MFN + Section 301 25% + Section 232 50% on full value since April 2026).
+					// Consumer Appliances (steel derivatives) - ~51.5% (MFN ~1.5% + Section 301 25% + Section 232 25%).
+					// 8418/8450/8451 are listed in Annex I-B (Section 232 25% on full customs value since 6 Apr 2026), NOT the 50% Annex I-A tier.
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
-						'hs_code_pattern' => '8418*,8450*,8451*',  // Refrigerators, washers, dryers (Section 232 derivative list).
+						'hs_code_pattern' => '8418*,8450*,8451*',  // Refrigerators, washers, dryers (Section 232 Annex I-B derivatives).
 						'type'            => 'percentage',
-						'rate'            => 76,  // MFN plus Section 301 plus Section 232 (full customs value since April 2026).
+						'rate'            => 51.5,  // MFN ~1.5% + Section 301 25% + Section 232 25% (Annex I-B, full customs value since 6 Apr 2026).
 						'priority'        => 30,
 						'stacking_mode'   => 'exclusive',
 						'label'           => __( 'China Appliances (Section 301 + 232)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Industrial Machinery - ~28% (MFN ~1.5% + Section 301 25%; most 8419 lines are outside the Section 232 derivative list, unlike fridges/washers/dryers).
+					// Industrial Machinery - ~28% (MFN ~1.5% + Section 301 25%) for the non-derivative subset.
+					// Note: some 8419 codes (e.g. 8419.50 heat exchangers, 8419.90.10 water-heater parts) ARE in Annex I-B at Section 232 25%, so those run ~51%.
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '8419*',  // Machinery for temperature-change treatment of materials.
 						'type'            => 'percentage',
-						'rate'            => 28,  // MFN plus Section 301.
+						'rate'            => 28,  // MFN + Section 301 (representative; some 8419 subheadings carry Section 232 25%).
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
 						'label'           => __( 'China Industrial Machinery (Section 301)', 'customs-fees-for-woocommerce' ),
@@ -290,13 +294,14 @@ class CFWC_Templates {
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// General baseline (MFN) - ~3% (fallback for unspecified products).
+					// General baseline (MFN-only floor) - ~3% (fallback for unspecified products).
+					// Most China-origin goods also carry Section 301 (+7.5% List 4A to +25% List 3), so actual duty is usually higher.
 					array(
 						'from_country'  => 'CN',
 						'to_country'    => 'US',
 						'match_type'    => 'all',  // Fallback for other products.
 						'type'          => 'percentage',
-						'rate'          => 3,  // Trade-weighted Column-1 MFN average.
+						'rate'          => 3,  // Trade-weighted Column-1 MFN average (excludes Section 301).
 						'priority'      => 5,  // Lowest priority (fallback).
 						'stacking_mode' => 'exclusive',  // Prevents stacking confusion.
 						'label'         => __( 'China General Import (MFN)', 'customs-fees-for-woocommerce' ),

--- a/includes/class-cfwc-templates.php
+++ b/includes/class-cfwc-templates.php
@@ -206,17 +206,31 @@ class CFWC_Templates {
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Consumer Appliances - ~28% (MFN ~1.5% + Section 301 25%; Section 232 applies to steel content only).
+					// Consumer Appliances (steel-derivative) - ~76% (MFN + Section 301 25% + Section 232 50% on full value since April 2026).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
-						'hs_code_pattern' => '8418*,8419*,8450*,8451*',  // Refrigerators, machinery, washers, dryers.
+						'hs_code_pattern' => '8418*,8450*,8451*',  // Refrigerators, washers, dryers (Section 232 derivative list).
 						'type'            => 'percentage',
-						'rate'            => 28,  // MFN plus Section 301 (Section 232 on steel content varies).
+						'rate'            => 76,  // MFN plus Section 301 plus Section 232 (full customs value since April 2026).
+						'priority'        => 30,
+						'stacking_mode'   => 'exclusive',
+						'label'           => __( 'China Appliances (Section 301 + 232)', 'customs-fees-for-woocommerce' ),
+						'taxable'         => true,
+						'tax_class'       => '',
+					),
+					// Industrial Machinery - ~28% (MFN ~1.5% + Section 301 25%; not on the Section 232 derivative list).
+					array(
+						'from_country'    => 'CN',
+						'to_country'      => 'US',
+						'match_type'      => 'hs_code',
+						'hs_code_pattern' => '8419*',  // Machinery for temperature-change treatment of materials.
+						'type'            => 'percentage',
+						'rate'            => 28,  // MFN plus Section 301.
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
-						'label'           => __( 'China Consumer Appliances', 'customs-fees-for-woocommerce' ),
+						'label'           => __( 'China Industrial Machinery (Section 301)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
@@ -262,14 +276,14 @@ class CFWC_Templates {
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Chemical Products - ~30% (MFN ~5% + Section 301 List 1/2/3 25%).
+					// Chemical Products - ~28% (MFN ~3% + Section 301 List 3 25%).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '28*,29*,38*',  // Various chemicals.
 						'type'            => 'percentage',
-						'rate'            => 30,  // MFN plus Section 301.
+						'rate'            => 28,  // MFN plus Section 301 List 3.
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
 						'label'           => __( 'China Chemical Products (Section 301)', 'customs-fees-for-woocommerce' ),

--- a/includes/class-cfwc-templates.php
+++ b/includes/class-cfwc-templates.php
@@ -220,7 +220,7 @@ class CFWC_Templates {
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Industrial Machinery - ~28% (MFN ~1.5% + Section 301 25%; not on the Section 232 derivative list).
+					// Industrial Machinery - ~28% (MFN ~1.5% + Section 301 25%; most 8419 lines are outside the Section 232 derivative list, unlike fridges/washers/dryers).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',

--- a/includes/class-cfwc-templates.php
+++ b/includes/class-cfwc-templates.php
@@ -77,20 +77,20 @@ class CFWC_Templates {
 			),
 
 			'china_to_us'              => array(
-				'name'        => __( 'China to US Import Tariffs (2025)', 'customs-fees-for-woocommerce' ),
-				'description' => __( '⚠️ COMPLETE PRESET: Clear existing rules before applying! This preset includes ALL China→US tariffs (Section 301, 232, fentanyl). No additional US import rules needed.', 'customs-fees-for-woocommerce' ),
+				'name'        => __( 'China to US Import Tariffs (2026)', 'customs-fees-for-woocommerce' ),
+				'description' => __( '⚠️ COMPLETE PRESET: Clear existing rules before applying! This preset includes China→US tariffs (Section 301 and Section 232). Rates reflect the durable regime after the IEEPA tariffs were struck down in February 2026. No additional US import rules needed.', 'customs-fees-for-woocommerce' ),
 				'rules'       => array(
-					// Apparel/Clothing - 7.5% to 70% (Section 301 + baseline, particularly high ~69%).
+					// Apparel/Clothing - ~24% (MFN base ~16.5% + Section 301 List 4A 7.5%).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '61*,62*',  // Apparel & Clothing.
 						'type'            => 'percentage',
-						'rate'            => 69,  // High rate for apparel.
+						'rate'            => 24,  // MFN base plus Section 301 List 4A.
 						'priority'        => 30,
 						'stacking_mode'   => 'exclusive',
-						'label'           => __( 'China Apparel (Section 301 + Fentanyl)', 'customs-fees-for-woocommerce' ),
+						'label'           => __( 'China Apparel (Section 301)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
@@ -136,112 +136,112 @@ class CFWC_Templates {
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Auto Parts - 25%.
+					// Auto Parts - ~52.5% (MFN 2.5% + Section 301 25% + Section 232 auto-parts 25%).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '8708*',  // Auto parts.
 						'type'            => 'percentage',
-						'rate'            => 25,  // Auto parts rate.
+						'rate'            => 52.5,  // Section 301 plus Section 232 auto-parts.
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
-						'label'           => __( 'China Auto Parts (25%)', 'customs-fees-for-woocommerce' ),
+						'label'           => __( 'China Auto Parts (Section 301 + 232)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Steel Products - 25% to 50% (Section 232).
+					// Steel Products - ~78% (MFN ~3% + Section 301 25% + Section 232 50%).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '72*,73*',  // Steel & Iron Products.
 						'type'            => 'percentage',
-						'rate'            => 25,  // Section 232 steel tariffs.
+						'rate'            => 78,  // Section 301 plus Section 232 (50% since June 2025).
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
-						'label'           => __( 'China Steel (Section 232)', 'customs-fees-for-woocommerce' ),
+						'label'           => __( 'China Steel (Section 301 + 232)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Aluminum Products - 25% to 50% (Section 232).
+					// Aluminum Products - ~78% (MFN ~3% + Section 301 25% + Section 232 50%).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '76*',  // Aluminum Products.
 						'type'            => 'percentage',
-						'rate'            => 25,  // Section 232 aluminum tariffs.
+						'rate'            => 78,  // Section 301 plus Section 232 (50% since June 2025).
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
-						'label'           => __( 'China Aluminum (Section 232)', 'customs-fees-for-woocommerce' ),
+						'label'           => __( 'China Aluminum (Section 301 + 232)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Batteries (Non-lithium and Lithium) - 25%.
+					// Batteries (Non-lithium and Lithium) - ~28% (MFN ~3.4% + Section 301 25%).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '8506*,8507*',  // Batteries.
 						'type'            => 'percentage',
-						'rate'            => 25,  // Section 301 increase Sept 27, 2024.
+						'rate'            => 28,  // MFN plus Section 301 (lithium at 25% from Jan 2026).
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
-						'label'           => __( 'China Batteries (25%)', 'customs-fees-for-woocommerce' ),
+						'label'           => __( 'China Batteries (Section 301)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Medical Devices - Syringes/Needles 50%, Medical Gloves 25%.
+					// Medical Devices - Syringes/Needles 100% (Section 301).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '9018.31*,9018.32*',  // Syringes and needles.
 						'type'            => 'percentage',
-						'rate'            => 50,  // 50% on syringes/needles from 2026.
+						'rate'            => 100,  // Section 301 100% finalized Sept 27, 2024.
 						'priority'        => 30,
 						'stacking_mode'   => 'exclusive',
-						'label'           => __( 'China Medical Syringes/Needles (50%)', 'customs-fees-for-woocommerce' ),
+						'label'           => __( 'China Medical Syringes/Needles (100%)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Consumer Appliances - 25% to 50%.
+					// Consumer Appliances - ~28% (MFN ~1.5% + Section 301 25%; Section 232 applies to steel content only).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '8418*,8419*,8450*,8451*',  // Refrigerators, machinery, washers, dryers.
 						'type'            => 'percentage',
-						'rate'            => 25,  // Section 232 steel derivative items.
+						'rate'            => 28,  // MFN plus Section 301 (Section 232 on steel content varies).
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
 						'label'           => __( 'China Consumer Appliances', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Footwear - 7.5% to 15%.
+					// Footwear - ~27% (MFN varies widely by material ~20% + Section 301 List 4A 7.5%).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '64*',  // Footwear.
 						'type'            => 'percentage',
-						'rate'            => 7.5,  // Section 301 List 4A tariffs.
+						'rate'            => 27,  // MFN plus Section 301 List 4A (highly material-dependent).
 						'priority'        => 20,
 						'stacking_mode'   => 'exclusive',
 						'label'           => __( 'China Footwear (Section 301)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Leather goods and bags - 25%.
+					// Leather goods and bags - ~35% (MFN ~10% + Section 301 List 3 25%; textile bags skew higher).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '4202*',  // Trunks, bags, cases, wallets, etc.
 						'type'            => 'percentage',
-						'rate'            => 25,
+						'rate'            => 35,  // MFN plus Section 301 List 3.
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
 						'label'           => __( 'China Leather Goods & Bags', 'customs-fees-for-woocommerce' ),
@@ -262,27 +262,27 @@ class CFWC_Templates {
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// Chemical Products - 25%.
+					// Chemical Products - ~30% (MFN ~5% + Section 301 List 1/2/3 25%).
 					array(
 						'from_country'    => 'CN',
 						'to_country'      => 'US',
 						'match_type'      => 'hs_code',
 						'hs_code_pattern' => '28*,29*,38*',  // Various chemicals.
 						'type'            => 'percentage',
-						'rate'            => 25,  // Section 301 chemicals.
+						'rate'            => 30,  // MFN plus Section 301.
 						'priority'        => 25,
 						'stacking_mode'   => 'exclusive',
-						'label'           => __( 'China Chemical Products (25%)', 'customs-fees-for-woocommerce' ),
+						'label'           => __( 'China Chemical Products (Section 301)', 'customs-fees-for-woocommerce' ),
 						'taxable'         => true,
 						'tax_class'       => '',
 					),
-					// General baseline (MFN) - ~7% (fallback for unspecified products).
+					// General baseline (MFN) - ~3% (fallback for unspecified products).
 					array(
 						'from_country'  => 'CN',
 						'to_country'    => 'US',
 						'match_type'    => 'all',  // Fallback for other products.
 						'type'          => 'percentage',
-						'rate'          => 7,  // WTO baseline tariff.
+						'rate'          => 3,  // Trade-weighted Column-1 MFN average.
 						'priority'      => 5,  // Lowest priority (fallback).
 						'stacking_mode' => 'exclusive',  // Prevents stacking confusion.
 						'label'         => __( 'China General Import (MFN)', 'customs-fees-for-woocommerce' ),

--- a/languages/customs-fees-for-woocommerce.pot
+++ b/languages/customs-fees-for-woocommerce.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPL v2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Customs Fees for WooCommerce 1.1.9\n"
+"Project-Id-Version: Customs Fees for WooCommerce 1.2.1\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/customs-fees-for-woocommerce\n"
-"POT-Creation-Date: 2026-05-29 10:17:08+00:00\n"
+"POT-Creation-Date: 2026-06-25 13:38:13+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -179,7 +179,7 @@ msgid "Remember to click \"Save changes\" to persist these rules."
 msgstr ""
 
 #: includes/admin/class-cfwc-admin.php:564
-#: includes/class-cfwc-templates.php:1523
+#: includes/class-cfwc-templates.php:1542
 msgid "Failed to apply preset."
 msgstr ""
 
@@ -386,25 +386,25 @@ msgstr ""
 msgid "No CSV content provided."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:477
+#: includes/admin/class-cfwc-ajax.php:472
 msgid "No valid rules found in CSV."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:503
+#: includes/admin/class-cfwc-ajax.php:498
 #. translators: %d: Number of rules imported
 msgid "%d rules imported successfully."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:530
+#: includes/admin/class-cfwc-ajax.php:525
 msgid "Invalid test parameters."
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:613
-#: includes/admin/class-cfwc-ajax.php:638
+#: includes/admin/class-cfwc-ajax.php:608
+#: includes/admin/class-cfwc-ajax.php:633
 msgid "Customs Fee"
 msgstr ""
 
-#: includes/admin/class-cfwc-ajax.php:652
+#: includes/admin/class-cfwc-ajax.php:647
 msgid "Calculation complete."
 msgstr ""
 
@@ -978,18 +978,21 @@ msgid "US Tariff (General)"
 msgstr ""
 
 #: includes/class-cfwc-templates.php:80
-msgid "China to US Import Tariffs (2025)"
+msgid "China to US Import Tariffs (2026)"
 msgstr ""
 
 #: includes/class-cfwc-templates.php:81
 msgid ""
-"⚠️ COMPLETE PRESET: Clear existing rules before applying! This preset "
-"includes ALL China→US tariffs (Section 301, 232, fentanyl). No additional "
-"US import rules needed."
+"⚠️ COMPLETE PRESET: Clear existing rules before applying! Applies "
+"representative China→US tariffs for the durable regime after the IEEPA "
+"tariffs were struck down in February 2026 (MFN base + Section 301, plus "
+"Section 232 where applicable). Rates are per-category representatives, not "
+"exact HTS duties. Excludes the temporary Section 122 import surcharge in "
+"effect through 24 July 2026. Confirm exact duties for your products."
 msgstr ""
 
 #: includes/class-cfwc-templates.php:93
-msgid "China Apparel (Section 301 + Fentanyl)"
+msgid "China Apparel (Section 301)"
 msgstr ""
 
 #: includes/class-cfwc-templates.php:107
@@ -1001,535 +1004,539 @@ msgid "China Solar/Semiconductors (50%)"
 msgstr ""
 
 #: includes/class-cfwc-templates.php:135
-msgid "China Electric Vehicles (100%)"
+msgid "China Electric Vehicles (Section 301)"
 msgstr ""
 
 #: includes/class-cfwc-templates.php:149
-msgid "China Auto Parts (25%)"
+msgid "China Auto Parts (Section 301 + 232)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:163
-msgid "China Steel (Section 232)"
+#: includes/class-cfwc-templates.php:164
+msgid "China Steel (Section 301 + 232)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:177
-msgid "China Aluminum (Section 232)"
+#: includes/class-cfwc-templates.php:179
+msgid "China Aluminum (Section 301 + 232)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:191
-msgid "China Batteries (25%)"
+#: includes/class-cfwc-templates.php:193
+msgid "China Batteries (Section 301)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:205
-msgid "China Medical Syringes/Needles (50%)"
+#: includes/class-cfwc-templates.php:207
+msgid "China Medical Syringes/Needles (100%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:219
-msgid "China Consumer Appliances"
+#: includes/class-cfwc-templates.php:222
+msgid "China Appliances (Section 301 + 232)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:233
+#: includes/class-cfwc-templates.php:237
+msgid "China Industrial Machinery (Section 301)"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:251
 msgid "China Footwear (Section 301)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:247
+#: includes/class-cfwc-templates.php:265
 msgid "China Leather Goods & Bags"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:261
+#: includes/class-cfwc-templates.php:279
 msgid "China Toys & Games"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:275
-msgid "China Chemical Products (25%)"
-msgstr ""
-
-#: includes/class-cfwc-templates.php:288
-msgid "China General Import (MFN)"
-msgstr ""
-
-#: includes/class-cfwc-templates.php:297
-msgid "India to US (25%)"
-msgstr ""
-
-#: includes/class-cfwc-templates.php:298
-msgid "US reciprocal tariff for goods from India - 25%"
+#: includes/class-cfwc-templates.php:293
+msgid "China Chemical Products (Section 301)"
 msgstr ""
 
 #: includes/class-cfwc-templates.php:307
-msgid "US Tariff (India)"
+msgid "China General Import (MFN)"
 msgstr ""
 
 #: includes/class-cfwc-templates.php:316
-msgid "EU to US Import Tariffs (2025 Agreement)"
+msgid "India to US (25%)"
 msgstr ""
 
 #: includes/class-cfwc-templates.php:317
+msgid "US reciprocal tariff for goods from India - 25%"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:326
+msgid "US Tariff (India)"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:335
+msgid "EU to US Import Tariffs (2025 Agreement)"
+msgstr ""
+
+#: includes/class-cfwc-templates.php:336
 msgid ""
 "⚠️ COMPLETE EU PRESET: 15% tariff on all 27 EU member states per Aug 2025 "
 "trade agreement. Special handling for cars, semiconductors, "
 "pharmaceuticals. Aircraft parts and generic pharma exempt."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:328
+#: includes/class-cfwc-templates.php:347
 msgid "US-EU Tariff (Germany)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:340
+#: includes/class-cfwc-templates.php:359
 msgid "US-EU Tariff (France)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:352
+#: includes/class-cfwc-templates.php:371
 msgid "US-EU Tariff (Italy)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:364
+#: includes/class-cfwc-templates.php:383
 msgid "US-EU Tariff (Spain)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:376
+#: includes/class-cfwc-templates.php:395
 msgid "US-EU Tariff (Netherlands)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:388
+#: includes/class-cfwc-templates.php:407
 msgid "US-EU Tariff (Belgium)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:400
+#: includes/class-cfwc-templates.php:419
 msgid "US-EU Tariff (Poland)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:412
+#: includes/class-cfwc-templates.php:431
 msgid "US-EU Tariff (Austria)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:424
+#: includes/class-cfwc-templates.php:443
 msgid "US-EU Tariff (Sweden)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:436
+#: includes/class-cfwc-templates.php:455
 msgid "US-EU Tariff (Denmark)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:448
+#: includes/class-cfwc-templates.php:467
 msgid "US-EU Tariff (Finland)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:460
+#: includes/class-cfwc-templates.php:479
 msgid "US-EU Tariff (Ireland)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:472
+#: includes/class-cfwc-templates.php:491
 msgid "US-EU Tariff (Portugal)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:484
+#: includes/class-cfwc-templates.php:503
 msgid "US-EU Tariff (Greece)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:496
+#: includes/class-cfwc-templates.php:515
 msgid "US-EU Tariff (Czech Rep.)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:508
+#: includes/class-cfwc-templates.php:527
 msgid "US-EU Tariff (Hungary)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:520
+#: includes/class-cfwc-templates.php:539
 msgid "US-EU Tariff (Romania)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:532
+#: includes/class-cfwc-templates.php:551
 msgid "US-EU Tariff (Bulgaria)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:544
+#: includes/class-cfwc-templates.php:563
 msgid "US-EU Tariff (Slovakia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:556
+#: includes/class-cfwc-templates.php:575
 msgid "US-EU Tariff (Croatia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:568
+#: includes/class-cfwc-templates.php:587
 msgid "US-EU Tariff (Slovenia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:580
+#: includes/class-cfwc-templates.php:599
 msgid "US-EU Tariff (Lithuania)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:592
+#: includes/class-cfwc-templates.php:611
 msgid "US-EU Tariff (Latvia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:604
+#: includes/class-cfwc-templates.php:623
 msgid "US-EU Tariff (Estonia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:616
+#: includes/class-cfwc-templates.php:635
 msgid "US-EU Tariff (Luxembourg)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:628
+#: includes/class-cfwc-templates.php:647
 msgid "US-EU Tariff (Cyprus)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:640
+#: includes/class-cfwc-templates.php:659
 msgid "US-EU Tariff (Malta)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:647
+#: includes/class-cfwc-templates.php:666
 msgid "UK to US (10%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:648
+#: includes/class-cfwc-templates.php:667
 msgid "US reciprocal tariff for goods from United Kingdom - 10%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:657
+#: includes/class-cfwc-templates.php:676
 msgid "US Tariff (UK)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:664
+#: includes/class-cfwc-templates.php:683
 msgid "Japan to US (15%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:665
+#: includes/class-cfwc-templates.php:684
 msgid "US reciprocal tariff for goods from Japan - 15%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:674
+#: includes/class-cfwc-templates.php:693
 msgid "US Tariff (Japan)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:681
+#: includes/class-cfwc-templates.php:700
 msgid "Brazil to US (10%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:682
+#: includes/class-cfwc-templates.php:701
 msgid "US reciprocal tariff for goods from Brazil - 10%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:691
+#: includes/class-cfwc-templates.php:710
 msgid "US Tariff (Brazil)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:698
+#: includes/class-cfwc-templates.php:717
 msgid "Switzerland to US (39%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:699
+#: includes/class-cfwc-templates.php:718
 msgid "US reciprocal tariff for goods from Switzerland - 39%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:708 includes/class-cfwc-templates.php:1008
+#: includes/class-cfwc-templates.php:727 includes/class-cfwc-templates.php:1027
 msgid "US Tariff (Switzerland)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:717
+#: includes/class-cfwc-templates.php:736
 msgid "Vietnam to US (20%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:718
+#: includes/class-cfwc-templates.php:737
 msgid "US reciprocal tariff for goods from Vietnam - 20%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:727 includes/class-cfwc-templates.php:1114
+#: includes/class-cfwc-templates.php:746 includes/class-cfwc-templates.php:1133
 msgid "US Tariff (Vietnam)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:734
+#: includes/class-cfwc-templates.php:753
 msgid "Thailand to US (19%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:735
+#: includes/class-cfwc-templates.php:754
 msgid "US reciprocal tariff for goods from Thailand - 19%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:744 includes/class-cfwc-templates.php:1125
+#: includes/class-cfwc-templates.php:763 includes/class-cfwc-templates.php:1144
 msgid "US Tariff (Thailand)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:751
+#: includes/class-cfwc-templates.php:770
 msgid "Indonesia to US (19%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:752
+#: includes/class-cfwc-templates.php:771
 msgid "US reciprocal tariff for goods from Indonesia - 19%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:761 includes/class-cfwc-templates.php:1147
+#: includes/class-cfwc-templates.php:780 includes/class-cfwc-templates.php:1166
 msgid "US Tariff (Indonesia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:770
+#: includes/class-cfwc-templates.php:789
 msgid "Bangladesh to US (20%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:771
+#: includes/class-cfwc-templates.php:790
 msgid "US reciprocal tariff for goods from Bangladesh - 20%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:780
+#: includes/class-cfwc-templates.php:799
 msgid "US Tariff (Bangladesh)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:787
+#: includes/class-cfwc-templates.php:806
 msgid "Pakistan to US (19%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:788
+#: includes/class-cfwc-templates.php:807
 msgid "US reciprocal tariff for goods from Pakistan - 19%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:797
+#: includes/class-cfwc-templates.php:816
 msgid "US Tariff (Pakistan)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:806
+#: includes/class-cfwc-templates.php:825
 msgid "South Korea to US (15%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:807
+#: includes/class-cfwc-templates.php:826
 msgid "US reciprocal tariff for goods from South Korea - 15%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:816
+#: includes/class-cfwc-templates.php:835
 msgid "US Tariff (South Korea)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:823
+#: includes/class-cfwc-templates.php:842
 msgid "Taiwan to US (20%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:824
+#: includes/class-cfwc-templates.php:843
 msgid "US reciprocal tariff for goods from Taiwan - 20%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:833
+#: includes/class-cfwc-templates.php:852
 msgid "US Tariff (Taiwan)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:842
+#: includes/class-cfwc-templates.php:861
 msgid "Turkey to US (15%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:843
+#: includes/class-cfwc-templates.php:862
 msgid "US reciprocal tariff for goods from Turkey - 15%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:852
+#: includes/class-cfwc-templates.php:871
 msgid "US Tariff (Turkey)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:859
+#: includes/class-cfwc-templates.php:878
 msgid "Israel to US (15%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:860
+#: includes/class-cfwc-templates.php:879
 msgid "US reciprocal tariff for goods from Israel - 15%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:869
+#: includes/class-cfwc-templates.php:888
 msgid "US Tariff (Israel)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:878
+#: includes/class-cfwc-templates.php:897
 msgid "South Africa to US (30%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:879
+#: includes/class-cfwc-templates.php:898
 msgid "US reciprocal tariff for goods from South Africa - 30%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:888
+#: includes/class-cfwc-templates.php:907
 msgid "US Tariff (South Africa)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:895
+#: includes/class-cfwc-templates.php:914
 msgid "Nigeria to US (15%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:896
+#: includes/class-cfwc-templates.php:915
 msgid "US reciprocal tariff for goods from Nigeria - 15%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:905
+#: includes/class-cfwc-templates.php:924
 msgid "US Tariff (Nigeria)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:914
+#: includes/class-cfwc-templates.php:933
 msgid "New Zealand to US (15%)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:915
+#: includes/class-cfwc-templates.php:934
 msgid "US reciprocal tariff for goods from New Zealand - 15%"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:924
+#: includes/class-cfwc-templates.php:943
 msgid "US Tariff (New Zealand)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:932
+#: includes/class-cfwc-templates.php:951
 msgid "UK VAT & Duty"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:933
+#: includes/class-cfwc-templates.php:952
 msgid "UK import VAT (20%) and duty for international shipments"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:942
+#: includes/class-cfwc-templates.php:961
 msgid "UK VAT (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:955
+#: includes/class-cfwc-templates.php:974
 msgid "UK Duty (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:964
+#: includes/class-cfwc-templates.php:983
 msgid "Canada GST & Duty"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:965
+#: includes/class-cfwc-templates.php:984
 msgid "Canadian GST and import duties"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:974
+#: includes/class-cfwc-templates.php:993
 msgid "Canada GST (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:987
+#: includes/class-cfwc-templates.php:1006
 msgid "Canada Duty (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:998
+#: includes/class-cfwc-templates.php:1017
 msgid "US High Tariff Countries (30%+)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:999
+#: includes/class-cfwc-templates.php:1018
 msgid "Countries with 30% or higher US reciprocal tariffs"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1019
+#: includes/class-cfwc-templates.php:1038
 msgid "US Tariff (Syria)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1030
+#: includes/class-cfwc-templates.php:1049
 msgid "US Tariff (Myanmar)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1041
+#: includes/class-cfwc-templates.php:1060
 msgid "US Tariff (Laos)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1052
+#: includes/class-cfwc-templates.php:1071
 msgid "US Tariff (Iraq)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1063
+#: includes/class-cfwc-templates.php:1082
 msgid "US Tariff (Serbia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1074
+#: includes/class-cfwc-templates.php:1093
 msgid "US Tariff (Algeria)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1085
+#: includes/class-cfwc-templates.php:1104
 msgid "US Tariff (Bosnia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1096
+#: includes/class-cfwc-templates.php:1115
 msgid "US Tariff (Libya)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1104
+#: includes/class-cfwc-templates.php:1123
 msgid "US-Southeast Asia All Countries"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1105
+#: includes/class-cfwc-templates.php:1124
 msgid "All Southeast Asian countries with US reciprocal tariffs"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1136
+#: includes/class-cfwc-templates.php:1155
 msgid "US Tariff (Malaysia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1158
+#: includes/class-cfwc-templates.php:1177
 msgid "US Tariff (Philippines)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1169
+#: includes/class-cfwc-templates.php:1188
 msgid "US Tariff (Cambodia)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1180
+#: includes/class-cfwc-templates.php:1199
 msgid "US Tariff (Brunei)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1188
+#: includes/class-cfwc-templates.php:1207
 msgid "Australia GST & Duty"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1189
+#: includes/class-cfwc-templates.php:1208
 msgid "Australian GST (10%) and duty on imported goods"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1198
+#: includes/class-cfwc-templates.php:1217
 msgid "Australia GST (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1211
+#: includes/class-cfwc-templates.php:1230
 msgid "Australia Duty (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1220
+#: includes/class-cfwc-templates.php:1239
 msgid "New Zealand GST & Duty"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1221
+#: includes/class-cfwc-templates.php:1240
 msgid "New Zealand GST (15%) and duty on imported goods"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1230
+#: includes/class-cfwc-templates.php:1249
 msgid "New Zealand GST (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1243
+#: includes/class-cfwc-templates.php:1262
 msgid "New Zealand Duty (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1252
+#: includes/class-cfwc-templates.php:1271
 msgid "EU VAT & Duty"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1253
+#: includes/class-cfwc-templates.php:1272
 msgid "EU import VAT (20%) and duty for international shipments"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1262
+#: includes/class-cfwc-templates.php:1281
 msgid "EU VAT (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1275
+#: includes/class-cfwc-templates.php:1294
 msgid "EU Duty (Import)"
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1495
+#: includes/class-cfwc-templates.php:1514
 #. translators: %1$d: number of rules added, %2$d: number of duplicates skipped
 msgid "Added %1$d new rules. Skipped %2$d duplicates."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1500
+#: includes/class-cfwc-templates.php:1519
 msgid "All preset rules already exist. No rules added."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1504
+#: includes/class-cfwc-templates.php:1523
 #. translators: %d: number of rules added
 msgid "%d preset rules added successfully."
 msgstr ""
 
-#: includes/class-cfwc-templates.php:1509
+#: includes/class-cfwc-templates.php:1528
 msgid "All rules replaced with preset."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -195,6 +195,7 @@ Yes, through:
 = 1.2.1 - 2026-xx-xx =
 * Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
 * Tweak  - WooCommerce 10.9 Compatibility.
+* Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
 
 = 1.2.0 - 2026-06-01 =
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.

--- a/readme.txt
+++ b/readme.txt
@@ -192,10 +192,12 @@ Yes, through:
 
 == Changelog ==
 
+= 1.3.0 - 2026-xx-xx =
+* Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
+
 = 1.2.1 - 2026-xx-xx =
 * Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
 * Tweak  - WooCommerce 10.9 Compatibility.
-* Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
 
 = 1.2.0 - 2026-06-01 =
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.

--- a/tests/Unit/China_Preset_Rates_Test.php
+++ b/tests/Unit/China_Preset_Rates_Test.php
@@ -129,6 +129,25 @@ class China_Preset_Rates_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox The china_to_us preset still has exactly one rule per category after the appliance split.
+	 *
+	 * Guards against accidental duplication when the appliance rule was split into a
+	 * steel-derivative rule (8418/8450/8451) and an industrial-machinery rule (8419).
+	 */
+	public function test_rule_count_is_stable(): void {
+		$template = $this->sut->get_template( 'china_to_us' );
+		$this->assertCount( 16, $template['rules'], 'The china_to_us preset should have exactly 16 rules.' );
+	}
+
+	/**
+	 * @testdox The china_to_us preset name reflects the post-IEEPA (2026) recalibration.
+	 */
+	public function test_preset_name_reflects_2026(): void {
+		$template = $this->sut->get_template( 'china_to_us' );
+		$this->assertStringContainsString( '2026', $template['name'], 'The preset name should reflect the 2026 recalibration.' );
+	}
+
+	/**
 	 * @testdox The struck-down IEEPA "fentanyl" surcharge is no longer referenced in the preset.
 	 */
 	public function test_no_fentanyl_reference(): void {

--- a/tests/Unit/China_Preset_Rates_Test.php
+++ b/tests/Unit/China_Preset_Rates_Test.php
@@ -101,11 +101,12 @@ class China_Preset_Rates_Test extends \WC_Unit_Test_Case {
 			'aluminum'     => array( '76*', 78.0 ),
 			'batteries'    => array( '8506*,8507*', 28.0 ),
 			'syringes'     => array( '9018.31*,9018.32*', 100.0 ),
-			'appliances'   => array( '8418*,8419*,8450*,8451*', 28.0 ),
+			'appl_machine' => array( '8419*', 28.0 ),
+			'appl_metal'   => array( '8418*,8450*,8451*', 76.0 ),
 			'footwear'     => array( '64*', 27.0 ),
 			'leather'      => array( '4202*', 35.0 ),
 			'toys'         => array( '95*', 7.5 ),
-			'chemicals'    => array( '28*,29*,38*', 30.0 ),
+			'chemicals'    => array( '28*,29*,38*', 28.0 ),
 		);
 	}
 

--- a/tests/Unit/China_Preset_Rates_Test.php
+++ b/tests/Unit/China_Preset_Rates_Test.php
@@ -3,10 +3,14 @@
  * Unit tests for the china_to_us preset rates in CFWC_Templates.
  *
  * Covers CUSFEES-20: the China -> US preset rates were calibrated during the
- * IEEPA tariff period (April 2025 - February 2026). IEEPA tariffs were struck
- * down in February 2026, so the preset must reflect the durable post-IEEPA
+ * IEEPA tariff period (February 2025 - February 2026). IEEPA tariffs were struck
+ * down on 20 February 2026, so the preset must reflect the durable post-IEEPA
  * regime (MFN base + Section 301 + Section 232). The apparel rule in
  * particular was overstated at 69 percent and should be ~24 percent.
+ *
+ * The asserted rates are the intended *representative* per-category preset
+ * values (most MFN/Section 301 components vary by HS line), not exact legal
+ * duties. These tests guard the intended configuration, not statutory precision.
  *
  * @package Customs_Fees_For_WooCommerce
  */
@@ -67,7 +71,7 @@ class China_Preset_Rates_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox The china_to_us preset reflects the post-IEEPA durable tariff rates.
+	 * @testdox The china_to_us preset uses the intended representative post-IEEPA durable rates.
 	 *
 	 * @dataProvider provide_expected_rates
 	 *
@@ -86,7 +90,13 @@ class China_Preset_Rates_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Expected post-IEEPA rates per HS pattern.
+	 * Intended representative post-IEEPA rates per HS pattern.
+	 *
+	 * Values are per-category representatives (MFN base + Section 301, plus
+	 * Section 232 where applicable), not exact HTS duties. EVs are MFN 2.5% +
+	 * Section 301 100% (= 102.5%); appliances are Annex I-B derivatives at
+	 * Section 232 25% on full value (~51.5%); steel/aluminum are the primary
+	 * metal high-end (finished Annex I-B derivatives run lower, ~53%).
 	 *
 	 * @return array<string,array{0:string,1:float}>
 	 */
@@ -95,14 +105,14 @@ class China_Preset_Rates_Test extends \WC_Unit_Test_Case {
 			'apparel'      => array( '61*,62*', 24.0 ),
 			'electronics'  => array( '85*', 25.0 ),
 			'solar'        => array( '8541*,8542*', 50.0 ),
-			'ev'           => array( '8703.80*', 100.0 ),
+			'ev'           => array( '8703.80*', 102.5 ),
 			'auto_parts'   => array( '8708*', 52.5 ),
 			'steel'        => array( '72*,73*', 78.0 ),
 			'aluminum'     => array( '76*', 78.0 ),
 			'batteries'    => array( '8506*,8507*', 28.0 ),
 			'syringes'     => array( '9018.31*,9018.32*', 100.0 ),
 			'appl_machine' => array( '8419*', 28.0 ),
-			'appl_metal'   => array( '8418*,8450*,8451*', 76.0 ),
+			'appl_metal'   => array( '8418*,8450*,8451*', 51.5 ),
 			'footwear'     => array( '64*', 27.0 ),
 			'leather'      => array( '4202*', 35.0 ),
 			'toys'         => array( '95*', 7.5 ),
@@ -166,5 +176,27 @@ class China_Preset_Rates_Test extends \WC_Unit_Test_Case {
 				);
 			}
 		}
+	}
+
+	/**
+	 * @testdox The preset description discloses the representative basis and excludes the temporary Section 122 surcharge.
+	 */
+	public function test_description_discloses_section_122_exclusion(): void {
+		$template = $this->sut->get_template( 'china_to_us' );
+		$this->assertStringNotContainsStringIgnoringCase(
+			'No additional US import rules needed',
+			$template['description'],
+			'The description must not claim no additional rules apply while the temporary Section 122 surcharge is in effect.'
+		);
+		$this->assertStringContainsString(
+			'Section 122',
+			$template['description'],
+			'The description should disclose that the temporary Section 122 surcharge is excluded.'
+		);
+		$this->assertStringContainsStringIgnoringCase(
+			'representative',
+			$template['description'],
+			'The description should state that the rates are representative, not exact duties.'
+		);
 	}
 }

--- a/tests/Unit/China_Preset_Rates_Test.php
+++ b/tests/Unit/China_Preset_Rates_Test.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Unit tests for the china_to_us preset rates in CFWC_Templates.
+ *
+ * Covers CUSFEES-20: the China -> US preset rates were calibrated during the
+ * IEEPA tariff period (April 2025 - February 2026). IEEPA tariffs were struck
+ * down in February 2026, so the preset must reflect the durable post-IEEPA
+ * regime (MFN base + Section 301 + Section 232). The apparel rule in
+ * particular was overstated at 69 percent and should be ~24 percent.
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\CustomsFees\Tests\Unit;
+
+/**
+ * @covers \CFWC_Templates::get_template
+ */
+class China_Preset_Rates_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var \CFWC_Templates
+	 */
+	private $sut;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->sut = new \CFWC_Templates();
+	}
+
+	/**
+	 * Find a china_to_us rule by its hs_code_pattern.
+	 *
+	 * @param string $pattern The hs_code_pattern to match.
+	 * @return array<string,mixed>|null The matching rule, or null.
+	 */
+	private function rule_by_pattern( string $pattern ): ?array {
+		$template = $this->sut->get_template( 'china_to_us' );
+		foreach ( $template['rules'] as $rule ) {
+			if ( isset( $rule['hs_code_pattern'] ) && $pattern === $rule['hs_code_pattern'] ) {
+				return $rule;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * The MFN fallback rule has no hs_code_pattern, so match it by match_type.
+	 *
+	 * @return array<string,mixed>|null The matching rule, or null.
+	 */
+	private function mfn_rule(): ?array {
+		$template = $this->sut->get_template( 'china_to_us' );
+		foreach ( $template['rules'] as $rule ) {
+			if ( isset( $rule['match_type'] ) && 'all' === $rule['match_type'] ) {
+				return $rule;
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @testdox The china_to_us preset reflects the post-IEEPA durable tariff rates.
+	 *
+	 * @dataProvider provide_expected_rates
+	 *
+	 * @param string $pattern The hs_code_pattern identifying the rule.
+	 * @param float  $expected The expected post-IEEPA rate.
+	 */
+	public function test_preset_rates_are_post_ieepa( string $pattern, float $expected ): void {
+		$rule = $this->rule_by_pattern( $pattern );
+		$this->assertNotNull( $rule, "Rule for pattern {$pattern} should exist." );
+		$this->assertEqualsWithDelta(
+			$expected,
+			(float) $rule['rate'],
+			0.001,
+			"Rule {$pattern} should use the post-IEEPA rate {$expected}."
+		);
+	}
+
+	/**
+	 * Expected post-IEEPA rates per HS pattern.
+	 *
+	 * @return array<string,array{0:string,1:float}>
+	 */
+	public function provide_expected_rates(): array {
+		return array(
+			'apparel'      => array( '61*,62*', 24.0 ),
+			'electronics'  => array( '85*', 25.0 ),
+			'solar'        => array( '8541*,8542*', 50.0 ),
+			'ev'           => array( '8703.80*', 100.0 ),
+			'auto_parts'   => array( '8708*', 52.5 ),
+			'steel'        => array( '72*,73*', 78.0 ),
+			'aluminum'     => array( '76*', 78.0 ),
+			'batteries'    => array( '8506*,8507*', 28.0 ),
+			'syringes'     => array( '9018.31*,9018.32*', 100.0 ),
+			'appliances'   => array( '8418*,8419*,8450*,8451*', 28.0 ),
+			'footwear'     => array( '64*', 27.0 ),
+			'leather'      => array( '4202*', 35.0 ),
+			'toys'         => array( '95*', 7.5 ),
+			'chemicals'    => array( '28*,29*,38*', 30.0 ),
+		);
+	}
+
+	/**
+	 * @testdox The china_to_us MFN fallback uses the post-IEEPA baseline rate.
+	 */
+	public function test_mfn_fallback_rate_is_post_ieepa(): void {
+		$rule = $this->mfn_rule();
+		$this->assertNotNull( $rule, 'The MFN fallback rule should exist.' );
+		$this->assertEqualsWithDelta( 3.0, (float) $rule['rate'], 0.001, 'MFN baseline should be ~3 percent.' );
+	}
+
+	/**
+	 * @testdox No china_to_us rate is still set at the IEEPA-era apparel value of 69 percent.
+	 */
+	public function test_apparel_rate_is_not_ieepa_value(): void {
+		$rule = $this->rule_by_pattern( '61*,62*' );
+		$this->assertNotNull( $rule );
+		$this->assertNotEquals( 69, (float) $rule['rate'], 'The IEEPA-era 69 percent apparel rate must be removed.' );
+	}
+
+	/**
+	 * @testdox The struck-down IEEPA "fentanyl" surcharge is no longer referenced in the preset.
+	 */
+	public function test_no_fentanyl_reference(): void {
+		$template = $this->sut->get_template( 'china_to_us' );
+		$this->assertStringNotContainsStringIgnoringCase(
+			'fentanyl',
+			$template['description'],
+			'The preset description should not cite the struck-down IEEPA fentanyl surcharge.'
+		);
+		foreach ( $template['rules'] as $rule ) {
+			if ( isset( $rule['label'] ) ) {
+				$this->assertStringNotContainsStringIgnoringCase(
+					'fentanyl',
+					$rule['label'],
+					'No rule label should cite the struck-down IEEPA fentanyl surcharge.'
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes CUSFEES-20

### Description

The built-in "China to US Import Tariffs" preset was calibrated during the IEEPA tariff period (February 2025 to February 2026). The US Supreme Court struck down the IEEPA tariffs (the "fentanyl" surcharge and the April 2025 reciprocal tariffs) on 20 February 2026 (*Learning Resources v. Trump*, 6-3), so the preset overstated import fees.

The worst case was the apparel rule (HS 61, 62) hardcoded at 69%, roughly three times the current effective rate of about 24% (MFN base plus Section 301 List 4A). A fashion brand reported this through a customer review ticket and manually corrected it to 25%, which led to a 3-star review.

This PR recalibrates every China to US rule to the durable post-IEEPA regime (MFN base plus Section 301 and Section 232 where applicable), removes the now-defunct IEEPA "fentanyl" wording, and renames the preset to "China to US Import Tariffs (2026)". Each rate was checked against public sources and set to a **representative** per-category value (most MFN/Section 301 components vary by HS line); they are not exact per-line legal duties. The preset description now says so and discloses that the temporary Section 122 surcharge is excluded.

### Changes in this PR

- Corrected the apparel rate (HS 61, 62) from 69% to 24%.
- Recalibrated the other China to US rules to current Section 301/232 levels: auto parts 25 → 52.5, steel 25 → 78, aluminum 25 → 78, batteries 25 → 28, medical syringes/needles 50 → 100, footwear 7.5 → 27, leather goods and bags 25 → 35, chemicals 25 → 28, and the MFN fallback 7 → 3. Electronics (25), solar/semiconductors (50), and toys (7.5) were already correct and are unchanged.
- **Electric vehicles (HS 8703.80): 100 → 102.5.** The customs duty is additive on the entered value, so the durable figure is the 2.5% Column-1 MFN base **plus** the 100% Section 301 strategic rate = 102.5% (every other rule already includes its MFN base). The 25% Section 232 auto tariff is excluded here (a complete vehicle would total 127.5%); it remains in the 8708 auto-parts line.
- **Consumer appliances (HS 8418, 8450, 8451): 76 → 51.5.** These refrigerators, washers and dryers are listed in **Annex I-B** of Proclamation 11021, which is the **25%** Section 232 tier on full customs value (effective 6 April 2026) — not the 50% Annex I-A "primary metal" tier. The earlier 76% applied the 50% rate to the new full-value base, double-counting the increase. Corrected to MFN ~1.5% + Section 301 25% + Section 232 25% ≈ 51.5%.
- Split out industrial machinery (HS 8419) at 28% (MFN + Section 301). Note: this is representative for the non-derivative subset — a few 8419 codes (e.g. 8419.50 heat exchangers, 8419.90.10 water-heater parts) **are** in Annex I-B at Section 232 25% and run ~51%.
- Steel (72, 73) and aluminum (76) are kept at 78% as a conservative high-end for **primary** metal (Annex I-A, Section 232 50%). Most finished Chapter 73 / aluminum articles are Annex I-B derivatives at Section 232 25% (~53% total). Flagged in code comments; lower these if your catalog is predominantly finished goods.
- Removed the struck-down IEEPA "fentanyl" surcharge wording from the preset description and rule labels.
- Reworded the preset description: removed the inaccurate "No additional US import rules needed" (a temporary ~10% Section 122 surcharge is live through 24 July 2026), added a representative-rates caveat, and disclosed the Section 122 exclusion.
- Updated unit tests (`tests/Unit/China_Preset_Rates_Test.php`): synced the EV (102.5) and appliance (51.5) expectations, reframed the data provider/docblock as **intended representative** values (not exact legal duties), and added a guard that the description discloses the Section 122 exclusion and does not claim "no additional rules".
- Added changelog entries to `changelog.txt`, `readme.txt`, and `README.md`.
- Regenerated the translation template (`languages/customs-fees-for-woocommerce.pot`) so it carries the updated preset name and rule labels and no longer ships the struck-down "fentanyl" wording.

### Test Instructions

1. Checkout this branch locally.
2. Run the unit tests: `composer test -- --filter=China_Preset_Rates_Test` (21 cases). PHPStan and `php -l` are clean on the changed files.
3. In wp-admin, go to WooCommerce > Settings > Tax > Customs Fees and apply the "China to US Import Tariffs (2026)" preset.
4. Confirm the "China Apparel (Section 301)" rule shows 24% (not 69%), that the "China Electric Vehicles (Section 301)" rule shows 102.5%, that the "China Appliances (Section 301 + 232)" rule shows 51.5%, and that no rule or the preset description mentions "fentanyl".
5. Confirm the preset description mentions Section 122 and the word "representative", and does **not** say "No additional US import rules needed".
6. Add a Chinese-origin apparel product (HS code starting 61 or 62) to a US-destination cart and confirm the customs fee reflects ~24% of the product value.

### Things to check

- [x] Are all texts internationalized? (all labels/description use `__()`)
- [ ] Has a cache been added? (n/a - preset data only)
- [ ] Are the hooks/filters called only when necessary? (n/a)
- [x] Have the local logs been checked to ensure this PR does not introduce new errors? (PHPStan clean on the changed class; `php -l` clean. The full WP-unit suite runs in wp-env/CI.)

---

## Rate verification (for reviewer)

Verified mid-2026, post-IEEPA. **Durable layers only**: MFN/Column-1 + Section 301 + Section 232. Explicitly excluded as **non-durable**: the IEEPA "fentanyl" + reciprocal tariffs (struck down 20 Feb 2026) and the temporary ~10% **Section 122** surcharge (in effect 24 Feb – 24 Jul 2026; statutorily capped at 150 days). The Section 122 exclusion is now disclosed in the preset description.

**Legal backdrop:** The Supreme Court held that IEEPA does not authorize tariffs and struck down the IEEPA tariffs on 20 February 2026 (*Learning Resources v. Trump*, 6-3). Section 301 (2024 four-year-review increases) and Section 232 (steel/aluminum/copper and autos) survive and form the durable regime.

| HS pattern | Category | Rate | Components | Verdict | Conf |
|---|---|---|---|---|---|
| 61*,62* | Apparel | 24 | MFN ~16.5% + 301 List 4A 7.5% | representative | High |
| 85* | Electronics | 25 | low MFN + 301 (List 3 25% / List 4A 7.5%) | representative (range-bound) | Med |
| 8541*,8542* | Solar/semis | 50 | 0% MFN + 301 50% | confirmed | High |
| 8703.80* | Electric vehicles | **102.5** (was 100) | 2.5% MFN + 301 100% (excl. 232 auto 25% → 127.5% if added) | **corrected** | High |
| 8708* | Auto parts | 52.5 | 2.5% MFN + 301 25% + 232 auto 25% | confirmed | Med-High |
| 72*,73* | Steel | 78 | primary metal (Annex I-A): MFN ~3% + 301 25% + 232 50%. Finished Annex I-B derivatives ~53% | representative high-end | Med-High |
| 76* | Aluminum | 78 | same basis as steel | representative high-end | Med-High |
| 8506*,8507* | Batteries | 28 | MFN 3.4% + 301 25% (lithium) | confirmed | Med-High |
| 9018.31*,9018.32* | Syringes/needles | 100 | 0% MFN + 301 100% (eff. 27 Sep 2024; enteral excl. expired 1 Jan 2026) | confirmed | High |
| 8418*,8450*,8451* | Appliances (fridge/washer/dryer) | **51.5** (was 76) | MFN ~1.5% + 301 25% + 232 25% (Annex I-B, full value since 6 Apr 2026) | **corrected** | High |
| 8419* | Industrial machinery | 28 | MFN ~1.5% + 301 25% (non-derivative subset; some 8419 are Annex I-B 25% → ~51%) | representative | Med |
| 64* | Footwear | 27 | MFN ~20% repr. + 301 List 4A 7.5% | representative (range-bound) | Med |
| 4202* | Leather/bags | 35 | MFN ~9-10% + 301 List 3 25% | representative | Med |
| 95* | Toys | 7.5 | 0% MFN + 301 List 4A 7.5% | confirmed | High |
| 28*,29*,38* | Chemicals | 28 | MFN ~3% + 301 List 3 25% | representative | Med |
| all (fallback) | General MFN floor | 3 | Column-1 trade-weighted avg; **excludes 301** | MFN-only floor | Med |

**Two values were corrected during review:**
- **EV 100 → 102.5** — 100% is only the Section 301 component; the durable figure adds the 2.5% MFN base (consistent with every other rule). If the Section 232 auto tariff (25%, as applied to 8708) is also layered on complete vehicles, it is 127.5%.
- **Appliances 76 → 51.5** — refrigerators/washers/dryers are Annex I-B derivatives (Section 232 **25%** on full value), not the 50% Annex I-A primary-metal tier. The White House Annex I-B list confirms 8418.10/.30/.40, 8450.11/.20, 8451.21/.29 at 25%.

Electronics, footwear, leather, chemicals and the MFN fallback are genuinely range-bound; their single values are defensible representatives and the preset now states the rates are representative and subject to change.

### Sources

**Legal backdrop (IEEPA struck down; Section 122 replacement):**
- Supreme Court slip opinion 24-1287 (*Learning Resources v. Trump*): https://www.supremecourt.gov/opinions/25pdf/24-1287_4gcj.pdf
- Holland & Knight — IEEPA struck down, 301/232 remain: https://www.hklaw.com/en/insights/publications/2026/02/supreme-court-strikes-down-ieepa-tariffs
- Perkins Coie — termination + Section 122: https://perkinscoie.com/insights/update/supreme-court-holds-ieepa-tariffs-unlawful-president-trump-terminates-and-partially
- Covington — Section 122 replacement (10%, 24 Feb – 24 Jul 2026, all countries incl. China): https://www.cov.com/en/news-and-insights/insights/2026/02/ieepa-tariffs-terminated-replacement-section-122-tariffs-take-effect

**Section 301 (Four-Year Review strategic increases — EV 100, solar 50, semis 50, syringes 100, batteries 25):**
- USTR final action: https://ustr.gov/about-us/policy-offices/press-office/press-releases/2024/september/ustr-finalizes-action-china-tariffs-following-statutory-four-year-review
- Federal Register 2024-21217: https://www.federalregister.gov/documents/2024/09/18/2024-21217/notice-of-modification-chinas-acts-policies-and-practices-related-to-technology-transfer
- C.H. Robinson Section 301 guide (List 3 25%, List 4A 7.5%): https://www.chrobinson.com/en-us/resources/resource-center/guides/section-301-china-tariff-guide/

**Section 232 steel/aluminum 50% (June 2025) and the April 2026 restructuring (full value; Annex I-A 50% vs Annex I-B 25%):**
- Federal Register 2025-10524 (steel/aluminum to 50%, eff. 4 June 2025): https://www.federalregister.gov/documents/2025/06/09/2025-10524/adjusting-imports-of-aluminum-and-steel-into-the-united-states
- Federal Register 2026-06960 (Proclamation 11021, full value + tiers, eff. 6 April 2026): https://www.federalregister.gov/documents/2026/04/09/2026-06960/strengthening-actions-taken-to-adjust-imports-of-aluminum-steel-and-copper-into-the-united-states
- White House **Annex I-B** (25% Section 232 on full value; lists the appliance/8419 codes): https://www.whitehouse.gov/wp-content/uploads/2026/06/Annex-I-B.pdf
- CBP CSMS #68253075 (entry guidance; full customs value): https://content.govdelivery.com/accounts/USDHSCBP/bulletins/4117593
- CBP Section 232 FAQ (232 additive to 301 + MFN): https://www.cbp.gov/trade/programs-administration/entry-summary/232-tariffs-aluminum-and-steel-faqs
- KPMG — new 232 calculation rules, 50%/25% tiers, full value: https://kpmg.com/us/en/taxnewsflash/news/2026/04/united-states-new-rules-calculating-section-232-tariffs-steel-aluminum-copper.html
- GEODIS — Annex I-A 50% (articles) vs Annex I-B 25% (derivatives): https://geodis.com/us-en/resources/customs-corner/united-states-announces-changes-section-232-steel-aluminum-and-copper
- Troutman (232 auto parts 25%, 301 stacks): https://www.troutman.com/insights/us-assembly-offset-for-section-232-auto-tariffs-and-tariff-stacking-guidance-introduced/
- Cassidy Levy (appliances on the 232 derivative list): https://www.cassidylevy.com/news/commerce-adds-appliances-to-section-232-derivative-products-list/

**Category specifics:**
- Apparel ~24% breakdown (MFN avg + List 4A 7.5%): https://shenglufashion.com/tag/section-301/
- Appliance MFN bases (fridge Free, washer 1.4%, dryer 3.4%): https://hts.usitc.gov/ (headings 8418.10, 8450.11, 8451.21)
- WTO US tariff profile (simple avg MFN ~3.3%): https://www.wto.org/english/res_e/statis_e/daily_update_e/tariff_profiles/US_e.pdf

### Scope note

A few rates are representative single values for categories that vary by product (electronics, footwear, leather, chemicals, the MFN fallback). The plugin lets merchants override any rate, and the preset description now states the rates are representative and exclude the temporary Section 122 surcharge. Steel/aluminum (72/73/76) are kept at the conservative primary-metal high-end; finished Annex I-B derivatives are lower (~53%) — adjust if your catalog is predominantly finished goods. The translation template (`.pot`) is regenerated in this PR so it matches the updated preset strings.

