### PR TITLE
Fix CUSFEES-22: allow EU as a rule destination/origin in the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,11 @@ GNU General Public License for more details.
 
 ## Changelog
 
+### Version 1.3.1
+
+- Added "EU Countries" as a selectable option in the rule editor's origin and destination country dropdowns, so EU-wide rules (such as the "EU VAT & Duty" preset) can be created and edited. Previously editing such a rule silently reset its destination to "Any", which applied the fee to every country.
+- Fixed the rule editor misreading a destination-only rule's legacy country field as its origin when editing.
+
 ### Version 1.3.0
 
 - Updated the China to US tariff preset rates to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -578,6 +578,17 @@
         '<option value="">' +
         (strings.select_country_placeholder || "Select country...") +
         "</option>";
+      // "EU Countries" is a supported pseudo-code for both the From and To
+      // fields (the rule matcher expands "EU" to all EU member states). Offer
+      // it explicitly so it can be selected manually and stays selected when
+      // editing a rule that already targets the EU (e.g. the "EU VAT & Duty"
+      // preset), instead of silently falling back to "Any".
+      html +=
+        '<option value="EU"' +
+        (selectedCountry === "EU" ? " selected" : "") +
+        ">" +
+        (strings.eu_countries || "EU Countries") +
+        "</option>";
       for (var code in countries) {
         html +=
           '<option value="' +
@@ -588,36 +599,6 @@
           countries[code] +
           "</option>";
       }
-      return html;
-    }
-
-    // Build origin country options (including special options).
-    function getOriginOptions(selectedOrigin) {
-      var html =
-        '<option value="">' +
-        (strings.all_origins || "All Origins") +
-        "</option>";
-      html +=
-        '<option value="EU"' +
-        (selectedOrigin === "EU" ? " selected" : "") +
-        ">" +
-        (strings.eu_countries || "EU Countries") +
-        "</option>";
-      html +=
-        '<optgroup label="' +
-        (strings.specific_country || "Specific Country") +
-        '">';
-      for (var code in countries) {
-        html +=
-          '<option value="' +
-          code +
-          '"' +
-          (code === selectedOrigin ? " selected" : "") +
-          ">" +
-          countries[code] +
-          "</option>";
-      }
-      html += "</optgroup>";
       return html;
     }
 
@@ -892,9 +873,11 @@
         '">';
       editRowHtml +=
         '<option value="">Any Origin</option>' +
-        getCountryOptions(
-          rule.from_country || rule.origin_country || rule.country || ""
-        );
+        // Origin falls back to the legacy `origin_country` only. Do NOT fall
+        // back to `country`: that legacy field holds the *destination*, so
+        // using it here would render a destination-only rule (e.g. the
+        // "EU VAT & Duty" preset) as if it also restricted the origin.
+        getCountryOptions(rule.from_country || rule.origin_country || "");
       editRowHtml += "</select>";
       editRowHtml +=
         '<select name="cfwc_rule_to_country" class="cfwc-rule-field cfwc-rule-field--country cfwc-country-select wc-enhanced-select cfwc-select2-field" data-field="to_country" data-placeholder="' +

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** Customs Fees for WooCommerce Changelog ***
 
+2026-07-06 - version 1.3.1
+* Fix    - Add "EU Countries" as a selectable option in the rule editor's origin and destination country dropdowns, so EU-wide rules (such as the "EU VAT & Duty" preset) can be created and edited. Previously editing such a rule silently reset its destination to "Any", which applied the fee to every country.
+* Fix    - The rule editor no longer misreads a destination-only rule's legacy country field as its origin when editing (the "EU VAT & Duty" preset incorrectly showed "EU" in the From field).
+
 2026-06-30 - version 1.3.0
 * Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
 

--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,10 @@ Yes, through:
 
 == Changelog ==
 
+= 1.3.1 - 2026-xx-xx =
+* Fix    - Add "EU Countries" as a selectable option in the rule editor's origin and destination country dropdowns, so EU-wide rules (such as the "EU VAT & Duty" preset) can be created and edited. Previously editing such a rule silently reset its destination to "Any", which applied the fee to every country.
+* Fix    - The rule editor no longer misreads a destination-only rule's legacy country field as its origin when editing (the "EU VAT & Duty" preset incorrectly showed "EU" in the From field).
+
 = 1.3.0 - 2026-xx-xx =
 * Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
 

--- a/tests/Unit/EU_Destination_Match_Test.php
+++ b/tests/Unit/EU_Destination_Match_Test.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * Unit tests for "EU" as a destination pseudo-code in rule matching.
+ *
+ * Covers CUSFEES-22: the "EU VAT & Duty" preset stores its rules with the
+ * destination set to the "EU" pseudo-code, which the rule matcher expands to
+ * all EU member states. The admin rule editor did not offer "EU" as a
+ * selectable destination, so editing (or re-saving) a preset rule silently
+ * dropped the "EU" value back to "Any" -- making the fee apply to every
+ * country. The dropdown fix relies on "EU" being a valid, matchable
+ * destination value; these tests guard that backend contract so the value the
+ * dropdown now preserves keeps behaving as intended.
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\CustomsFees\Tests\Unit;
+
+/**
+ * @covers \CFWC_Rule_Matcher::find_matching_rules
+ */
+class EU_Destination_Match_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * The System Under Test.
+	 *
+	 * @var \CFWC_Rule_Matcher
+	 */
+	private $matcher;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->matcher = new \CFWC_Rule_Matcher();
+	}
+
+	/**
+	 * Create a simple physical product.
+	 *
+	 * @return \WC_Product_Simple
+	 */
+	private function make_product(): \WC_Product_Simple {
+		$product = new \WC_Product_Simple();
+		$product->set_name( 'CFWC EU Destination Test' );
+		$product->set_regular_price( '100' );
+		$product->set_price( '100' );
+		$product->save();
+
+		return $product;
+	}
+
+	/**
+	 * Build an EU-destination rule.
+	 *
+	 * @param bool $legacy When true, only the legacy `country` field carries
+	 *                     the destination (no `to_country`), mirroring how the
+	 *                     "EU VAT & Duty" preset stores its rules.
+	 * @return array Rule data.
+	 */
+	private function eu_rule( bool $legacy = false ): array {
+		$rule = array(
+			'rule_id'          => 'eu_import',
+			'from_country'     => '',
+			'match_type'       => 'all',
+			'type'             => 'percentage',
+			'rate'             => 20,
+			'amount'           => 0,
+			'label'            => 'EU Import',
+			'taxable'          => false,
+			'tax_class'        => '',
+			'valuation_method' => 'cif',
+			'base_includes'    => array(),
+			'stacking_mode'    => 'add',
+			'priority'         => 0,
+		);
+
+		if ( $legacy ) {
+			// Legacy shape: destination lives in `country` only.
+			$rule['country'] = 'EU';
+		} else {
+			$rule['country']    = 'EU';
+			$rule['to_country'] = 'EU';
+		}
+
+		return $rule;
+	}
+
+	/**
+	 * @testdox An EU-destination rule matches an EU member state (Germany).
+	 */
+	public function test_eu_rule_matches_eu_destination(): void {
+		$survivors = $this->matcher->find_matching_rules( $this->make_product(), 'US', 'DE', array( $this->eu_rule() ) );
+
+		$this->assertContains(
+			'eu_import',
+			wp_list_pluck( $survivors, 'rule_id' ),
+			'A rule targeting the EU should match a German (EU) destination.'
+		);
+	}
+
+	/**
+	 * @testdox An EU-destination rule does NOT match a non-EU destination (US).
+	 *
+	 * This is the core of the bug: when the "EU" value is silently dropped to
+	 * "Any", the fee applies everywhere. As long as the destination is "EU",
+	 * a non-EU order must not match.
+	 */
+	public function test_eu_rule_does_not_match_non_eu_destination(): void {
+		$survivors = $this->matcher->find_matching_rules( $this->make_product(), 'CN', 'US', array( $this->eu_rule() ) );
+
+		$this->assertNotContains(
+			'eu_import',
+			wp_list_pluck( $survivors, 'rule_id' ),
+			'A rule targeting the EU must not match a US (non-EU) destination.'
+		);
+	}
+
+	/**
+	 * @testdox A legacy EU rule (destination in `country` only) still matches EU and not non-EU.
+	 *
+	 * The "EU VAT & Duty" preset stores its rules with the destination in the
+	 * legacy `country` field. The matcher must treat that identically to
+	 * `to_country`, otherwise a freshly applied preset would behave
+	 * differently from an edited one.
+	 */
+	public function test_legacy_eu_rule_matches_eu_only(): void {
+		$product = $this->make_product();
+
+		$matches_eu = wp_list_pluck(
+			$this->matcher->find_matching_rules( $product, 'US', 'FR', array( $this->eu_rule( true ) ) ),
+			'rule_id'
+		);
+		$matches_non_eu = wp_list_pluck(
+			$this->matcher->find_matching_rules( $product, 'US', 'GB', array( $this->eu_rule( true ) ) ),
+			'rule_id'
+		);
+
+		$this->assertContains( 'eu_import', $matches_eu, 'A legacy EU rule should match a French (EU) destination.' );
+		$this->assertNotContains( 'eu_import', $matches_non_eu, 'A legacy EU rule must not match a UK (non-EU) destination.' );
+	}
+
+	/**
+	 * @testdox The "EU VAT & Duty" preset targets the EU destination pseudo-code.
+	 *
+	 * Guards the config the admin dropdown must be able to represent: if the
+	 * preset ever stored a real ISO code (or "Any") here, the dropdown-fix
+	 * rationale would no longer hold.
+	 */
+	public function test_eu_vat_preset_targets_eu_destination(): void {
+		$templates = new \CFWC_Templates();
+		$preset    = $templates->get_template( 'eu_vat' );
+
+		$this->assertNotNull( $preset, 'The eu_vat preset should exist.' );
+		$this->assertNotEmpty( $preset['rules'], 'The eu_vat preset should define rules.' );
+
+		foreach ( $preset['rules'] as $rule ) {
+			$destination = $rule['to_country'] ?? $rule['country'] ?? '';
+			$this->assertSame(
+				'EU',
+				$destination,
+				'Every eu_vat preset rule should target the EU destination pseudo-code.'
+			);
+		}
+	}
+}


### PR DESCRIPTION
Fix: [CUSFEES-22](https://linear.app/a8c/issue/CUSFEES-22)

### Description

The rule editor's country dropdowns did not offer the "EU" pseudo-code that the rule matcher already supports (`CFWC_Rule_Matcher` expands "EU" to all member states). As a result the "EU VAT & Duty" preset could not be represented in the editor:

- There was no way to select the EU as a destination manually.
- Editing a preset rule silently reset its destination to "Any", so the fee applied to every country instead of only EU destinations.
- The From (origin) field fell back to the legacy `country` field — which holds the *destination* — so a destination-only preset rule showed "EU" as its origin, and saving would have restricted the rule to EU origins.

The backend already matched "EU" destinations correctly; this is an admin-editor fix.

### Changes in this PR

- Add "EU Countries" as a selectable option in `getCountryOptions()`, so both the From and To dropdowns can offer and preserve the "EU" value.
- Remove `getOriginOptions()`: it already contained an "EU Countries" option but was never called — both dropdowns render via `getCountryOptions()`. Folding the option into `getCountryOptions()` makes the dead helper redundant rather than wiring it up separately.
- Stop the From dropdown from falling back to the destination `country` field when selecting the origin.
- Add `tests/Unit/EU_Destination_Match_Test.php` guarding that an "EU" destination rule matches EU member states and not non-EU countries (incl. the legacy `country`-only shape the preset uses).

No version bump (release-managed via woorelease); changelog entries added under 1.3.1 in `changelog.txt`, `readme.txt`, `README.md`.

### Test Instructions

1. Checkout this branch locally (enable `SCRIPT_DEBUG`, or run `pnpm uglify` to rebuild `admin.min.js`).
2. WooCommerce → Settings → Tax → Customs Fees.
3. Click "Add rule" and open the To dropdown → "EU Countries" is selectable (From too).
4. Apply the "EU VAT & Duty" preset, edit one of its rules → From shows "Any", To shows "EU Countries". Save and confirm it persists (previously the destination reset to "Any" and the fee applied to all countries).
5. Set a product's country of origin (or a default origin), then check out to an EU country (e.g. Germany) → EU fee applies; check out to a non-EU country (e.g. US) → no EU fee.

### Things to check

- [x] Are all texts internationalized? — label uses the existing localized `strings.eu_countries`; no new strings added.
- [ ] Has a cache been added? — N/A (admin editor rendering only).
- [x] Are the hooks/filters called only when necessary? — no hook/filter changes.
- [ ] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications? — verified functionally on a test site (no admin errors observed) + `node --check`/`php -l`; full PHPUnit/PHPStan run in CI (local WC test DB unavailable in this environment).

---

This PR was created during the p6q7sZ-lkg-p2 via team Ceres' [`/bug-blitz` Claude skill](https://github.com/Automattic/public-resources-squad/blob/trunk/.claude/skills/bug-blitz/skill.md). The fix was authored with Claude Code assistance by a Happiness Engineer who encounters this bug in support tickets.