### PR TITLE
[CUSFEES-23] Tweak - WooCommerce 11.0 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Customs Fees for WooCommerce Changelog ***
 
+2026-xx-xx - version 1.3.1
+* Tweak - WooCommerce 11.0 Compatibility.
+
 2026-06-30 - version 1.3.0
 * Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
 

--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -14,8 +14,8 @@
  * Requires at least: 6.9
  * Tested up to:      7.0
  * Requires PHP:      7.4
- * WC requires at least: 10.7
- * WC tested up to:   10.9
+ * WC requires at least: 10.8
+ * WC tested up to:   11.0
  * Woo: 18734005702334:78cd9350327fbb9496bc3fbfd7335b53
  *
  * @package CustomsFeesForWooCommerce

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 6.9
 Tested up to: 7.0
 Requires PHP: 7.4
 Requires Plugins: woocommerce
-WC requires at least: 10.7
-WC tested up to: 10.9
+WC requires at least: 10.8
+WC tested up to: 11.0
 Stable tag: 1.1.8
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -191,6 +191,9 @@ Yes, through:
 8. Email with customs fee information
 
 == Changelog ==
+
+= 1.3.1 - 2026-xx-xx =
+* Tweak - WooCommerce 11.0 Compatibility.
 
 = 1.3.0 - 2026-xx-xx =
 * Update - China to US tariff preset rates refreshed to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.


### PR DESCRIPTION
Bumps WooCommerce compatibility headers for the WooCommerce 11.0 release. Tested with WooCommerce 11.0, no issues found.

- `WC requires at least`: 10.7 -> 10.8
- `WC tested up to`: 10.9 -> 11.0
- Added changelog entry for version 1.3.1.

Part of CUSFEES-23.
https://linear.app/a8c/issue/CUSFEES-23/ensure-woocommerce-110-compatibility-customs-fees-for-woocommerce
