### PR TITLE
Remove obsolete Product Block Editor compatibility declaration (WC 11.0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,7 +51,7 @@ docs/                   # Developer docs: CIF.md, HOWTO_DEBUG.md, QUICK_START.md
 - **Settings** live under WooCommerce > Settings > Tax > Customs Fees.
 - **Fee breakdown** stored in `WC()->session` for display in cart/checkout.
 - **Product meta**: `_cfwc_hs_code` and `_cfwc_country_of_origin` on postmeta.
-- HPOS, Cart/Checkout blocks, and product block editor compatibility declared.
+- HPOS and Cart/Checkout blocks compatibility declared.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,21 +12,21 @@
 
 **Plugin**: Customs Fees for WooCommerce
 **Purpose**: Calculate and display customs/import fees at WooCommerce checkout based on product origin, destination country, HS codes, and category rules.
-**Version**: 1.1.5
+**Version**: see the `Version` header in `customs-fees-for-woocommerce.php` (bumped by release tooling)
 
 ### Stack
 
 | Layer | Tool |
 |-------|------|
 | PHP | >= 7.4 (no namespaces, `CFWC_` prefix convention) |
-| WordPress | >= 6.8, tested up to 6.9 |
-| WooCommerce | >= 10.4, tested up to 10.6 |
+| WordPress | >= 6.9, tested up to 7.0 |
+| WooCommerce | >= 10.8, tested up to 11.0 |
 | Node | 22.14.0 (pinned in `.nvmrc`) |
 | Package manager | pnpm >= 10.4.1 |
 | JS minification | UglifyJS (`uglify-js`) |
 | CSS minification | clean-css-cli |
 | i18n | node-wp-i18n |
-| Static analysis | PHPStan level 0 with `phpstan-wordpress` + `woocommerce-stubs` |
+| Static analysis | PHPStan level 2 with `phpstan-wordpress` + `woocommerce-stubs` |
 | Release packaging | `composer archive` |
 
 ### Key Directories
@@ -86,8 +86,8 @@ vendor/bin/phpstan analyse
 # Lint PHP (PHPCS)
 # Not yet configured -- no .phpcs.xml in repo
 
-# Run PHP unit tests
-# Not yet implemented -- no tests/ directory or phpunit.xml
+# Run PHP unit tests (PHPUnit, config in phpunit.xml.dist, suites in tests/Unit/)
+composer test
 
 # Start wp-env
 npx wp-env start
@@ -149,4 +149,4 @@ QIT (Quality Insights Toolkit) E2E tests run remotely via `.github/workflows/qit
 
 ## Skills and Additional Guidance
 
-Developer docs in `docs/`: CIF.md (valuation feature), HOWTO_DEBUG.md (logging), QUICK_START.md (setup), TESTING.md (manual test scenarios - no automated tests exist yet).
+Developer docs in `docs/`: CIF.md (valuation feature), HOWTO_DEBUG.md (logging), QUICK_START.md (setup), TESTING.md (manual test scenarios; automated unit tests live in `tests/Unit/`).

--- a/README.md
+++ b/README.md
@@ -344,6 +344,14 @@ GNU General Public License for more details.
 
 ## Changelog
 
+### Version 1.3.2
+
+- Removed the obsolete product block editor compatibility declaration, following the removal of that feature in WooCommerce 11.0.
+
+### Version 1.3.1
+
+- WooCommerce 11.0 Compatibility.
+
 ### Version 1.3.0
 
 - Updated the China to US tariff preset rates to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ With the U.S. ending its de minimis exemption on **August 29, 2025**, all intern
 
 ### Minimum requirements
 
-- WordPress 6.0 or higher
-- WooCommerce 9.0 or higher
+- WordPress 6.9 or higher
+- WooCommerce 10.8 or higher
 - PHP 7.4 or higher
 
 ### Manual installation

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Customs Fees for WooCommerce Changelog ***
 
+2026-xx-xx - version 1.3.2
+* Tweak - Remove product block editor compatibility declaration.
+
 2026-07-27 - version 1.3.1
 * Tweak - WooCommerce 11.0 Compatibility.
 

--- a/includes/class-cfwc-loader.php
+++ b/includes/class-cfwc-loader.php
@@ -211,13 +211,6 @@ class CFWC_Loader {
 				CFWC_PLUGIN_FILE,
 				true
 			);
-
-			// Product block editor compatibility.
-			\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility(
-				'product_block_editor',
-				CFWC_PLUGIN_FILE,
-				true
-			);
 		}
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,9 @@ Yes, through:
 
 == Changelog ==
 
+= 1.3.2 - 2026-xx-xx =
+* Tweak - Remove product block editor compatibility declaration.
+
 = 1.3.1 - 2026-xx-xx =
 * Tweak - WooCommerce 11.0 Compatibility.
 


### PR DESCRIPTION
* Fix #

### Description

WooCommerce 11.0 removed the product block editor beta ([woocommerce/woocommerce#65319](https://github.com/woocommerce/woocommerce/issues/65319)) with no replacement. The plugin only declared `product_block_editor` feature compatibility via `FeaturesUtil` - it never used the block templates API directly - so the declaration is now obsolete and is removed. HPOS and Cart/Checkout blocks compatibility declarations are unchanged.

### Changes in this PR

- Remove the `product_block_editor` `FeaturesUtil::declare_compatibility()` call in `CFWC_Loader::declare_compatibility()`.
- Update the AGENTS.md architecture note to drop the "product block editor" mention.

### Test Instructions

1. Checkout this branch locally.
2. `vendor/bin/phpstan analyse` - no errors (level 0).
3. `php -l includes/class-cfwc-loader.php` - no syntax errors.
4. Load any admin page (e.g. WooCommerce > Settings > Tax > Customs Fees) with `WP_DEBUG` on - no deprecation notices or warnings from the compatibility declaration.

### Things to check

- [x] Are all texts internationalized?
- [x] Has a cache been added?
- [x] Are the hooks/filters called only when necessary?
- [x] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications?

### Changelog entry

> Tweak - Remove product block editor compatibility declaration.