### PR TITLE
Fix doc inconsistencies in AGENTS.md, README.md, docs/TESTING.md

### DIFF
--- a/.github/workflows/merge_to_trunk.yml
+++ b/.github/workflows/merge_to_trunk.yml
@@ -1,9 +1,9 @@
-name: Merge to Main CI
+name: Merge to Trunk CI
 
 on:
   pull_request:
     branches:
-      - main
+      - trunk
     types:
       - closed
 

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -21,7 +21,7 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
     branches:
-      - main
+      - trunk
 
 permissions:
   contents: read

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ assets/css/             # Source CSS (admin.css, admin-improvements.css, fronten
 assets/js/              # Source JS (admin.js, frontend.js)
 languages/              # POT file only; translations are not auto-loaded (see Empty load_textdomain() note)
 docs/                   # Developer docs: CIF.md, HOWTO_DEBUG.md, QUICK_START.md, TESTING.md
-.github/workflows/      # CI: QIT tests, build, release, merge-to-main
+.github/workflows/      # CI: QIT tests, build, release, merge-to-trunk
 ```
 
 ### Architecture Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,7 @@ assets/css/             # Source CSS (admin.css, admin-improvements.css, fronten
 assets/js/              # Source JS (admin.js, frontend.js)
 languages/              # POT file only; translations are not auto-loaded (see Empty load_textdomain() note)
 docs/                   # Developer docs: CIF.md, HOWTO_DEBUG.md, QUICK_START.md, TESTING.md
-.github/workflows/      # CI: QIT tests, build, release, merge-to-trunk
+.github/workflows/      # CI: QIT tests, build, release, merge-to-main
 ```
 
 ### Architecture Notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,8 +19,8 @@
 | Layer | Tool |
 |-------|------|
 | PHP | >= 7.4 (no namespaces, `CFWC_` prefix convention) |
-| WordPress | >= 6.9, tested up to 7.0 |
-| WooCommerce | >= 10.8, tested up to 11.0 |
+| WordPress | see `Requires at least` / `Tested up to` headers in `customs-fees-for-woocommerce.php` |
+| WooCommerce | see `WC requires at least` / `WC tested up to` headers in `customs-fees-for-woocommerce.php` |
 | Node | 22.14.0 (pinned in `.nvmrc`) |
 | Package manager | pnpm >= 10.4.1 |
 | JS minification | UglifyJS (`uglify-js`) |
@@ -37,9 +37,9 @@ includes/admin/         # Admin-only classes (loaded conditionally via is_admin(
 includes/admin/views/   # Admin view templates (rules-section.php)
 assets/css/             # Source CSS (admin.css, admin-improvements.css, frontend.css)
 assets/js/              # Source JS (admin.js, frontend.js)
-languages/              # POT file only -- translations loaded by WordPress automatically
+languages/              # POT file only; translations are not auto-loaded (see Empty load_textdomain() note)
 docs/                   # Developer docs: CIF.md, HOWTO_DEBUG.md, QUICK_START.md, TESTING.md
-.github/workflows/      # CI: QIT tests, build, release, merge-to-main
+.github/workflows/      # CI: QIT tests, build, release, merge-to-trunk
 ```
 
 ### Architecture Notes
@@ -109,7 +109,7 @@ npx wp-env logs
 
 ### Branches
 
-- `main` -- stable, release-ready code.
+- `trunk` -- stable, release-ready code.
 - Feature/fix branches: `add/CUSFEES-*`, `tweak/CUSFEES-*`, `fix/CUSFEES-*`.
 
 ### Pull Requests
@@ -132,7 +132,7 @@ QIT (Quality Insights Toolkit) E2E tests run remotely via `.github/workflows/qit
 
 - **No namespaces by design**: The plugin predates namespace adoption and uses the `CFWC_` prefix convention consistently. Do not refactor to namespaces without explicit approval.
 - **Manual require_once loading**: `CFWC_Loader::load_dependencies()` handles all includes. Admin classes are conditionally loaded behind `is_admin()`.
-- **Empty `load_textdomain()`**: Intentionally empty -- WordPress 4.6+ auto-loads translations for WordPress.org-hosted plugins. Do not add `load_plugin_textdomain()` calls.
+- **Empty `load_textdomain()`**: The main plugin class does not call `load_plugin_textdomain()`. This plugin is not hosted on WordPress.org, so the WordPress 4.6+ just-in-time auto-loading that covers .org-hosted plugins does not apply here. Without a `load_plugin_textdomain()` call, only translations installed globally in `WP_LANG_DIR/plugins/` are found; bundled `.mo` files in `languages/` are not loaded. This is currently harmless because `languages/` ships only a `.pot` and no `.mo` files, but the first shipped translation would be silently ignored. Whether to implement `load_plugin_textdomain()` is a separate decision (own ticket).
 - **Stub AJAX handlers in Loader**: `ajax_save_rules`, `ajax_delete_rule`, `ajax_load_template` in `CFWC_Loader` are stubs. Actual AJAX handling is in `CFWC_Ajax`.
 - **composer archive for packaging**: Release ZIPs are built via `composer archive` with exclusion rules in `composer.json`. The `.gitattributes` file also controls `export-ignore`.
 - **Rules dual storage**: Rules are stored via `cfwc_rules` option and cached via `cfwc_rules_cache` transient.

--- a/README.md
+++ b/README.md
@@ -364,7 +364,6 @@ GNU General Public License for more details.
 ### Version 1.2.0 - June 2026
 
 - Added per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
-- Fixed rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
 - Fixed missing confirmation dialog when leaving page or saving settings with an unsaved rule open.
 - Updated built-in presets for Canada, Australia, New Zealand, UK, and EU to use correct duty vs. import tax valuation bases.
 - The `cfwc_customs_value` filter now passes the matching rule as a 5th argument; existing 4-argument callbacks remain backwards-compatible.

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ With the U.S. ending its de minimis exemption on **August 29, 2025**, all intern
 
 ### Minimum requirements
 
-- WordPress 6.9 or higher
-- WooCommerce 10.8 or higher
+- WordPress: see the `Requires at least` header in `customs-fees-for-woocommerce.php`
+- WooCommerce: see the `WC requires at least` header in `customs-fees-for-woocommerce.php`
 - PHP 7.4 or higher
 
 ### Manual installation
@@ -344,22 +344,30 @@ GNU General Public License for more details.
 
 ## Changelog
 
-### Version 1.3.2
+### Version 1.3.2 - Unreleased
 
 - Removed the obsolete product block editor compatibility declaration, following the removal of that feature in WooCommerce 11.0.
 
-### Version 1.3.1
+### Version 1.3.1 - July 2026
 
-- WooCommerce 11.0 Compatibility.
+- WooCommerce 11.0 compatibility.
 
-### Version 1.3.0
+### Version 1.3.0 - June 2026
 
 - Updated the China to US tariff preset rates to reflect the current import regime after the IEEPA tariffs were struck down in February 2026; the apparel rate is corrected from 69% to about 24%.
 
-### Version 1.2.0
+### Version 1.2.1 - June 2026
 
 - Fixed rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
+- WooCommerce 10.9 compatibility.
+
+### Version 1.2.0 - June 2026
+
+- Added per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
+- Fixed rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
 - Fixed missing confirmation dialog when leaving page or saving settings with an unsaved rule open.
+- Updated built-in presets for Canada, Australia, New Zealand, UK, and EU to use correct duty vs. import tax valuation bases.
+- The `cfwc_customs_value` filter now passes the matching rule as a 5th argument; existing 4-argument callbacks remain backwards-compatible.
 
 ### Version 1.1.9 - May 2026
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,7 +15,6 @@
 
 2026-06-01 - version 1.2.0
 * Add    - Per-rule valuation overrides (FOB, CIF, CIF + Insurance) with compound base support, so a rule's customs value can include other rules' computed fees.
-* Fix    - Rules with a blank destination country ("Any") or blank origin and destination ("Any → Any") being silently discarded on save and disappearing after page reload.
 * Fix    - Show confirmation dialog when leaving page or saving settings with an unsaved rule open.
 * Update - Built-in presets for Canada, Australia, New Zealand, UK, and EU now use correct duty vs. import tax valuation bases.
 * Dev    - `cfwc_customs_value` filter now passes the matching rule as a 5th argument; existing 4-argument callbacks remain backwards-compatible.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -35,7 +35,7 @@ This guide provides comprehensive testing procedures to ensure Customs Fees for 
 - **Local development**: Local by Flywheel, DevKinsta, or XAMPP
 - **WordPress**: Latest stable version and minimum supported (6.9)
 - **WooCommerce**: Latest stable version and minimum supported (10.8)
-- **PHP**: Test on 7.4, 8.0, 8.1, and 8.2
+- **PHP**: Test on 7.4 (minimum supported), 8.3, and 8.4
 - **Database**: MySQL 5.6+ or MariaDB 10.0+
 
 ### Essential test data
@@ -413,17 +413,7 @@ composer test
 
 ### End-to-end tests
 
-Using Playwright:
-
-```bash
-npm run test:e2e
-```
-
-Specific test:
-
-```bash
-npm run test:e2e -- --grep "checkout"
-```
+There is no local E2E suite. End-to-end coverage runs through WooCommerce QIT in CI (see the `qit` workflows in `.github/workflows/`).
 
 ### Continuous integration
 
@@ -529,7 +519,7 @@ Using Debug Bar:
 
 - [ ] WordPress 6.9+
 - [ ] WooCommerce 10.8+
-- [ ] PHP 7.4, 8.0, 8.1, 8.2
+- [ ] PHP 7.4, 8.3, 8.4
 - [ ] HPOS enabled
 - [ ] HPOS disabled
 - [ ] Block checkout

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -417,18 +417,13 @@ There is no local E2E suite. End-to-end coverage runs through WooCommerce QIT in
 
 ### Continuous integration
 
-GitHub Actions workflow runs on:
+CI runs WooCommerce QIT (Quality Insights Toolkit) tests remotely. There are no PHPUnit, PHPCS, or JavaScript test steps in CI -- PHPUnit runs locally only, via `composer test`.
 
-- Pull requests
-- Main branch commits
-- Release tags
+- `merge_to_trunk.yml` -- after a PR merges to `trunk`, builds the plugin and runs the QIT activation, security, phpcompatibility, validation, and phpstan tests.
+- `cron_qit.yml` -- weekly (Sundays at 02:00 UTC), runs the same tests plus woo-api, woo-e2e, and malware against WP stable / WC nightly.
+- `qit.yml` -- runs individual QIT tests on demand, via workflow dispatch or `needs: qit ... test` PR labels.
 
-Tests include:
-
-- PHPUnit (PHP 7.4, 8.0, 8.1, 8.2)
-- JavaScript tests
-- PHPCS coding standards
-- Plugin check validation
+The first two call `qit_runner.yml`, which defaults to PHP 8.4, while `qit.yml` runs the QIT CLI directly; the PHP versions in the recommended test environment above are manual-testing guidance and are not exercised by CI.
 
 ---
 
@@ -545,9 +540,8 @@ Using Debug Bar:
 
 #### Code quality
 
-- [ ] PHPCS passing
+- [ ] PHPStan passing
 - [ ] PHPUnit tests passing
-- [ ] JavaScript tests passing
 - [ ] No deprecated functions
 - [ ] Documentation complete
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -33,8 +33,8 @@ This guide provides comprehensive testing procedures to ensure Customs Fees for 
 ### Recommended test environment
 
 - **Local development**: Local by Flywheel, DevKinsta, or XAMPP
-- **WordPress**: Latest stable version and minimum supported (6.0)
-- **WooCommerce**: Latest stable version and minimum supported (8.0)
+- **WordPress**: Latest stable version and minimum supported (6.9)
+- **WooCommerce**: Latest stable version and minimum supported (10.8)
 - **PHP**: Test on 7.4, 8.0, 8.1, and 8.2
 - **Database**: MySQL 5.6+ or MariaDB 10.0+
 
@@ -282,9 +282,9 @@ Create three USD $10 fees and test each mode:
 
 ### 1. WordPress compatibility
 
-#### Test: Minimum version (6.0)
+#### Test: Minimum version (6.9)
 
-1. Install on WordPress 6.0
+1. Install on WordPress 6.9
 2. Test all features
 3. **Expected**: Full functionality
 
@@ -411,26 +411,6 @@ Run unit tests:
 composer test
 ```
 
-Test coverage:
-
-```bash
-composer test-coverage
-```
-
-### JavaScript tests
-
-Run Jest tests:
-
-```bash
-npm test
-```
-
-Watch mode:
-
-```bash
-npm test -- --watch
-```
-
 ### End-to-end tests
 
 Using Playwright:
@@ -547,8 +527,8 @@ Using Debug Bar:
 
 #### Compatibility
 
-- [ ] WordPress 6.0+
-- [ ] WooCommerce 8.0+
+- [ ] WordPress 6.9+
+- [ ] WooCommerce 10.8+
 - [ ] PHP 7.4, 8.0, 8.1, 8.2
 - [ ] HPOS enabled
 - [ ] HPOS disabled


### PR DESCRIPTION
* Fix CUSFEES-25

### Description

Several docs restated facts that tooling maintains elsewhere, so they drifted: hardcoded WP/WC minimums, a branch model referencing a non-existent main branch, non-existent test commands, and an i18n rationale that does not apply to this plugin.

### Changes in this PR

- AGENTS.md and README.md reference the plugin header for WP/WC minimums instead of restating version literals.
- AGENTS.md: branch model is trunk, not main; workflows comment updated.
- AGENTS.md: correct the empty load_textdomain() rationale - the plugin is not on WordPress.org, so .org auto-loading does not apply.
- README.md: add the missing 1.2.1 changelog entry, restore 1.2.0 to mirror changelog.txt, add Month Year suffixes to 1.3.1/1.3.2, fix 1.3.1 title case.
- docs/TESTING.md: drop non-existent composer test-coverage, npm test, and Playwright E2E sections, update WP/WC minimums to 6.9/10.8, refresh the PHP matrix, and rewrite the continuous integration section to describe the QIT workflows that actually run (no PHPUnit/PHPCS/JS steps exist in CI).
- changelog.txt: remove the 1.2.1 fix entry that was left duplicated under 1.2.0, so all three changelogs agree.
- .github/workflows: rename merge_to_main.yml to merge_to_trunk.yml and retarget its trigger (and qit.yml's PR trigger) from the non-existent main branch to trunk, so both workflows can actually fire.

### Test Instructions

1. Checkout this branch locally.
2. In AGENTS.md, confirm the Stack table and the README Minimum requirements reference the header; Branches says trunk; the load_textdomain() note no longer claims .org auto-loading.
3. In README.md, confirm the changelog has a 1.2.1 entry, a complete 1.2.0 entry, and 1.3.1/1.3.2 carry a Month Year suffix.
4. In docs/TESTING.md, confirm there is no composer test-coverage, npm test, or Playwright section, minimums are 6.9/10.8, and the CI section lists merge_to_trunk.yml, cron_qit.yml, and qit.yml.
5. In changelog.txt, confirm the blank-destination-country fix appears only under 1.2.1, not 1.2.0.
6. In .github/workflows, confirm merge_to_trunk.yml and qit.yml both filter pull_request on trunk and no workflow references a main branch.

### Things to check

- [x] Are all texts internationalized? N/A (no code change)
- [x] Has a cache been added? N/A
- [x] Are the hooks/filters called only when necessary? N/A
- [x] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications? N/A (docs and CI config only)
