### PR TITLE
[CUSFEES-26] Fix - Respect email customs filters in admin-triggered order emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,12 @@ GNU General Public License for more details.
 
 ## Changelog
 
-### Version 1.3.2
+### Version 1.3.3
 
 - Fixed the cfwc_show_origin_in_email and cfwc_show_hs_code_in_email filters being ignored, and customs info being duplicated, in order emails generated from an admin request.
+
+### Version 1.3.2
+
 - Removed the obsolete product block editor compatibility declaration, following the removal of that feature in WooCommerce 11.0.
 
 ### Version 1.3.1

--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ GNU General Public License for more details.
 
 ### Version 1.3.2
 
+- Fixed the cfwc_show_origin_in_email and cfwc_show_hs_code_in_email filters being ignored, and customs info being duplicated, in order emails generated from an admin request.
 - Removed the obsolete product block editor compatibility declaration, following the removal of that feature in WooCommerce 11.0.
 
 ### Version 1.3.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,9 @@
 *** Customs Fees for WooCommerce Changelog ***
 
-2026-08-05 - version 1.3.2
+2026-xx-xx - version 1.3.3
 * Fix - Origin and HS code shown in order emails despite the cfwc_show_origin_in_email and cfwc_show_hs_code_in_email filters, and customs info duplicated, when emails were generated from an admin request.
+
+2026-08-05 - version 1.3.2
 * Tweak - Remove product block editor compatibility declaration.
 
 2026-07-27 - version 1.3.1

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,7 @@
 *** Customs Fees for WooCommerce Changelog ***
 
 2026-08-05 - version 1.3.2
+* Fix - Origin and HS code shown in order emails despite the cfwc_show_origin_in_email and cfwc_show_hs_code_in_email filters, and customs info duplicated, when emails were generated from an admin request.
 * Tweak - Remove product block editor compatibility declaration.
 
 2026-07-27 - version 1.3.1

--- a/includes/class-cfwc-display.php
+++ b/includes/class-cfwc-display.php
@@ -266,6 +266,16 @@ class CFWC_Display {
 	 * @return string Modified item name.
 	 */
 	public function add_hs_code_to_order_item_display( $item_name, $item, $is_visible = true ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by hook signature.
+		// Emails are handled by CFWC_Emails, which applies the
+		// cfwc_show_hs_code_in_email and cfwc_show_origin_in_email filters.
+		// Emails can render while is_admin() is true (status change, resend,
+		// admin-ajax, Action Scheduler), so detect email context directly:
+		// HTML emails fire woocommerce_email_header, plain text emails only
+		// fire woocommerce_email_order_details.
+		if ( did_action( 'woocommerce_email_header' ) || did_action( 'woocommerce_email_order_details' ) ) {
+			return $item_name;
+		}
+
 		// Only add to order pages, not emails.
 		if ( ! is_wc_endpoint_url( 'view-order' ) && ! is_order_received_page() && ! is_admin() ) {
 			return $item_name;

--- a/readme.txt
+++ b/readme.txt
@@ -191,8 +191,10 @@ Yes, through:
 
 == Changelog ==
 
-= 1.3.2 - 2026-xx-xx =
+= 1.3.3 - 2026-xx-xx =
 * Fix - Origin and HS code shown in order emails despite the cfwc_show_origin_in_email and cfwc_show_hs_code_in_email filters, and customs info duplicated, when emails were generated from an admin request.
+
+= 1.3.2 - 2026-08-05 =
 * Tweak - Remove product block editor compatibility declaration.
 
 = 1.3.1 - 2026-07-27 =

--- a/readme.txt
+++ b/readme.txt
@@ -192,6 +192,7 @@ Yes, through:
 == Changelog ==
 
 = 1.3.2 - 2026-xx-xx =
+* Fix - Origin and HS code shown in order emails despite the cfwc_show_origin_in_email and cfwc_show_hs_code_in_email filters, and customs info duplicated, when emails were generated from an admin request.
 * Tweak - Remove product block editor compatibility declaration.
 
 = 1.3.1 - 2026-07-27 =

--- a/tests/Unit/Email_Customs_Filters_Test.php
+++ b/tests/Unit/Email_Customs_Filters_Test.php
@@ -22,16 +22,34 @@ namespace WooCommerce\CustomsFees\Tests\Unit;
 class Email_Customs_Filters_Test extends \WC_Unit_Test_Case {
 
 	/**
-	 * Reset email-context action counters, screen, and filters between tests.
+	 * Reset email-context state before each test: earlier tests in the run
+	 * may have fired the email actions (did_action() counters are sticky for
+	 * the whole PHP process) or set an admin screen.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->reset_email_context();
+	}
+
+	/**
+	 * Reset email-context state after each test to protect the rest of the
+	 * suite.
 	 */
 	public function tearDown(): void {
+		$this->reset_email_context();
+		parent::tearDown();
+	}
+
+	/**
+	 * Clear the email action counters, current screen, and email filters.
+	 */
+	private function reset_email_context(): void {
 		global $wp_actions, $current_screen;
 		unset( $wp_actions['woocommerce_email_header'] );
 		unset( $wp_actions['woocommerce_email_order_details'] );
 		$current_screen = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 		remove_all_filters( 'cfwc_show_hs_code_in_email' );
 		remove_all_filters( 'cfwc_show_origin_in_email' );
-		parent::tearDown();
 	}
 
 	/**
@@ -104,7 +122,7 @@ class Email_Customs_Filters_Test extends \WC_Unit_Test_Case {
 		$item = $this->order_item_with_customs_meta();
 
 		set_current_screen( 'edit-post' );
-		do_action( 'woocommerce_email_order_details', null, false, true, null );
+		do_action( 'woocommerce_email_order_details', $item->get_order(), false, true, null );
 
 		$name = $this->filtered_item_name( $item );
 

--- a/tests/Unit/Email_Customs_Filters_Test.php
+++ b/tests/Unit/Email_Customs_Filters_Test.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * Unit tests for the cfwc_show_hs_code_in_email and cfwc_show_origin_in_email
+ * filters on the woocommerce_order_item_name rendering paths.
+ *
+ * Covers CUSFEES-26: emails generated in an admin request context (order
+ * status change, resend email, admin-ajax, Action Scheduler async runner)
+ * were decorated by CFWC_Display::add_hs_code_to_order_item_display(), which
+ * ignores both email filters and duplicates the CFWC_Emails output.
+ *
+ * @package Customs_Fees_For_WooCommerce
+ */
+
+declare( strict_types=1 );
+
+namespace WooCommerce\CustomsFees\Tests\Unit;
+
+/**
+ * @covers \CFWC_Display::add_hs_code_to_order_item_display
+ * @covers \CFWC_Emails::add_hs_code_to_order_item
+ */
+class Email_Customs_Filters_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Reset email-context action counters, screen, and filters between tests.
+	 */
+	public function tearDown(): void {
+		global $wp_actions, $current_screen;
+		unset( $wp_actions['woocommerce_email_header'] );
+		unset( $wp_actions['woocommerce_email_order_details'] );
+		$current_screen = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		remove_all_filters( 'cfwc_show_hs_code_in_email' );
+		remove_all_filters( 'cfwc_show_origin_in_email' );
+		parent::tearDown();
+	}
+
+	/**
+	 * Build an order item for a simple product carrying customs meta.
+	 *
+	 * @return \WC_Order_Item_Product Order item.
+	 */
+	private function order_item_with_customs_meta() {
+		$product = \WC_Helper_Product::create_simple_product();
+		update_post_meta( $product->get_id(), '_cfwc_hs_code', '6109.10' );
+		update_post_meta( $product->get_id(), '_cfwc_country_of_origin', 'US' );
+
+		$order = \WC_Helper_Order::create_order( 1, $product );
+		$items = $order->get_items();
+
+		return array_shift( $items );
+	}
+
+	/**
+	 * Run the woocommerce_order_item_name filter as email templates do.
+	 *
+	 * @param \WC_Order_Item_Product $item Order item.
+	 * @return string Filtered item name.
+	 */
+	private function filtered_item_name( $item ) {
+		return apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
+	}
+
+	/**
+	 * HTML email rendered in an admin request: both filters set to false must
+	 * remove the HS code and the origin from the item name.
+	 */
+	public function test_email_filters_hide_customs_info_in_admin_context_email() {
+		$item = $this->order_item_with_customs_meta();
+
+		set_current_screen( 'edit-post' );
+		add_filter( 'cfwc_show_hs_code_in_email', '__return_false' );
+		add_filter( 'cfwc_show_origin_in_email', '__return_false' );
+
+		do_action( 'woocommerce_email_header', 'Heading', null );
+
+		$name = $this->filtered_item_name( $item );
+
+		$this->assertStringNotContainsString( 'Origin', $name );
+		$this->assertStringNotContainsString( 'HS Code', $name );
+	}
+
+	/**
+	 * HTML email rendered in an admin request with default filter values:
+	 * customs info must appear exactly once (no CFWC_Display duplication).
+	 */
+	public function test_customs_info_appears_once_in_admin_context_email() {
+		$item = $this->order_item_with_customs_meta();
+
+		set_current_screen( 'edit-post' );
+		do_action( 'woocommerce_email_header', 'Heading', null );
+
+		$name = $this->filtered_item_name( $item );
+
+		$this->assertSame( 1, substr_count( $name, 'Origin' ) );
+		$this->assertSame( 1, substr_count( $name, 'HS Code' ) );
+	}
+
+	/**
+	 * Plain-text emails never fire woocommerce_email_header but do fire
+	 * woocommerce_email_order_details; the display path must not inject HTML
+	 * into them even in an admin request context.
+	 */
+	public function test_plain_text_email_in_admin_context_gets_no_html() {
+		$item = $this->order_item_with_customs_meta();
+
+		set_current_screen( 'edit-post' );
+		do_action( 'woocommerce_email_order_details', null, false, true, null );
+
+		$name = $this->filtered_item_name( $item );
+
+		$this->assertSame( $item->get_name(), $name );
+	}
+
+	/**
+	 * Variation with the HS code stored on the variation and the origin on the
+	 * parent (the CUSFEES-26 reporter's setup): filters must still remove the
+	 * origin in an admin-context email.
+	 */
+	public function test_email_origin_filter_applies_to_variation_with_parent_origin() {
+		$parent = \WC_Helper_Product::create_variation_product();
+		update_post_meta( $parent->get_id(), '_cfwc_country_of_origin', 'US' );
+		$children     = $parent->get_children();
+		$variation_id = array_shift( $children );
+		update_post_meta( $variation_id, '_cfwc_hs_code', '6109.10' );
+
+		$order = \WC_Helper_Order::create_order( 1, wc_get_product( $variation_id ) );
+		$items = $order->get_items();
+		$item  = array_shift( $items );
+
+		set_current_screen( 'edit-post' );
+		add_filter( 'cfwc_show_hs_code_in_email', '__return_false' );
+		add_filter( 'cfwc_show_origin_in_email', '__return_false' );
+
+		do_action( 'woocommerce_email_header', 'Heading', null );
+
+		$name = $this->filtered_item_name( $item );
+
+		$this->assertStringNotContainsString( 'Origin', $name );
+	}
+
+	/**
+	 * Outside email rendering, the admin order screen must keep showing the
+	 * customs details regardless of the email filters.
+	 */
+	public function test_admin_order_screen_display_is_unaffected_by_email_filters() {
+		$item = $this->order_item_with_customs_meta();
+
+		set_current_screen( 'edit-post' );
+		add_filter( 'cfwc_show_hs_code_in_email', '__return_false' );
+		add_filter( 'cfwc_show_origin_in_email', '__return_false' );
+
+		$name = $this->filtered_item_name( $item );
+
+		$this->assertStringContainsString( 'HS Code: 6109.10', $name );
+		$this->assertStringContainsString( 'Origin: United States', $name );
+	}
+}


### PR DESCRIPTION
* Fix #34

### Description

The `cfwc_show_hs_code_in_email` and `cfwc_show_origin_in_email` filters are only applied in `CFWC_Emails`. A second callback on the same hook, `CFWC_Display::add_hs_code_to_order_item_display()`, also runs while emails render in admin-originated requests (status change, resend email, admin-ajax, Action Scheduler) because its guard relies on `is_admin()`. It adds the HS code and origin to email item names while ignoring both filters, and duplicates the info added by `CFWC_Emails`.

The fix makes the display callback return early during email rendering, detected via `did_action( 'woocommerce_email_header' )` for HTML emails and `did_action( 'woocommerce_email_order_details' )` for plain text emails. Emails are now handled only by `CFWC_Emails`, which respects both filters. This also stops HTML from being injected into plain text emails.

### Changes in this PR

- Early return in `CFWC_Display::add_hs_code_to_order_item_display()` when an email is rendering.
- New unit tests in `tests/Unit/Email_Customs_Filters_Test.php`.
- Changelog entries.

### Test Instructions

1. Checkout this branch and add:
   ```php
   add_filter( 'cfwc_show_hs_code_in_email', '__return_false' );
   add_filter( 'cfwc_show_origin_in_email', '__return_false' );
   ```
2. Order a product that has an HS code and a country of origin.
3. In wp-admin, change the order status (with an email logger active).
4. The email item names no longer include `Origin:` or `HS Code:`. Before the fix, `<small class="cfwc-order-customs">Origin: ...</small>` was still added.
5. Remove the filters and repeat step 3: the customs info appears once per item (it was duplicated before).
6. Run `composer test`: 61 tests pass.

### Things to check

- [x] Are all texts internationalized? (no new user-facing text)
- [x] Has a cache been added? (not needed)
- [x] Are the hooks/filters called only when necessary?
- [x] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications?
