### PR TITLE
[CUSFEES-30] Tweak - WordPress 7.1 Compatibility.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@
 | Layer | Tool |
 |-------|------|
 | PHP | >= 7.4 (no namespaces, `CFWC_` prefix convention) |
-| WordPress | >= 6.9, tested up to 7.0 |
+| WordPress | >= 7.0, tested up to 7.1 |
 | WooCommerce | >= 10.8, tested up to 11.0 |
 | Node | 22.14.0 (pinned in `.nvmrc`) |
 | Package manager | pnpm >= 10.4.1 |

--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ GNU General Public License for more details.
 ### Version 1.3.2
 
 - Removed the obsolete product block editor compatibility declaration, following the removal of that feature in WooCommerce 11.0.
+- WordPress 7.1 Compatibility.
 
 ### Version 1.3.1
 

--- a/README.md
+++ b/README.md
@@ -344,10 +344,13 @@ GNU General Public License for more details.
 
 ## Changelog
 
+### Version 1.3.3
+
+- WordPress 7.1 Compatibility.
+
 ### Version 1.3.2
 
 - Removed the obsolete product block editor compatibility declaration, following the removal of that feature in WooCommerce 11.0.
-- WordPress 7.1 Compatibility.
 
 ### Version 1.3.1
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@
 
 2026-08-05 - version 1.3.2
 * Tweak - Remove product block editor compatibility declaration.
+* Tweak - WordPress 7.1 Compatibility.
 
 2026-07-27 - version 1.3.1
 * Tweak - WooCommerce 11.0 Compatibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@
 2026-08-05 - version 1.3.2
 * Tweak - Remove product block editor compatibility declaration.
 * Tweak - WordPress 7.1 Compatibility.
+* Update - Raise the minimum supported WordPress version to 7.0.
 
 2026-07-27 - version 1.3.1
 * Tweak - WooCommerce 11.0 Compatibility.

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,9 +1,10 @@
 *** Customs Fees for WooCommerce Changelog ***
 
+2026-xx-xx - version 1.3.3
+* Tweak - WordPress 7.1 Compatibility.
+
 2026-08-05 - version 1.3.2
 * Tweak - Remove product block editor compatibility declaration.
-* Tweak - WordPress 7.1 Compatibility.
-* Update - Raise the minimum supported WordPress version to 7.0.
 
 2026-07-27 - version 1.3.1
 * Tweak - WooCommerce 11.0 Compatibility.

--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -11,8 +11,8 @@
  * Text Domain:       customs-fees-for-woocommerce
  * Domain Path:       /languages
  * Requires Plugins:  woocommerce
- * Requires at least: 6.9
- * Tested up to:      7.0
+ * Requires at least: 7.0
+ * Tested up to:      7.1
  * Requires PHP:      7.4
  * WC requires at least: 10.8
  * WC tested up to:   11.0

--- a/readme.txt
+++ b/readme.txt
@@ -191,9 +191,11 @@ Yes, through:
 
 == Changelog ==
 
+= 1.3.3 - 2026-xx-xx =
+* Tweak - WordPress 7.1 Compatibility.
+
 = 1.3.2 - 2026-xx-xx =
 * Tweak - Remove product block editor compatibility declaration.
-* Tweak - WordPress 7.1 Compatibility.
 
 = 1.3.1 - 2026-07-27 =
 * Tweak - WooCommerce 11.0 Compatibility.

--- a/readme.txt
+++ b/readme.txt
@@ -194,7 +194,7 @@ Yes, through:
 = 1.3.3 - 2026-xx-xx =
 * Tweak - WordPress 7.1 Compatibility.
 
-= 1.3.2 - 2026-xx-xx =
+= 1.3.2 - 2026-08-05 =
 * Tweak - Remove product block editor compatibility declaration.
 
 = 1.3.1 - 2026-07-27 =

--- a/readme.txt
+++ b/readme.txt
@@ -1,8 +1,8 @@
 === Customs Fees for WooCommerce ===
 Contributors: woocommerce
 Tags: woocommerce, customs, import-fees, international-shipping, tariffs
-Requires at least: 6.9
-Tested up to: 7.0
+Requires at least: 7.0
+Tested up to: 7.1
 Requires PHP: 7.4
 Requires Plugins: woocommerce
 WC requires at least: 10.8
@@ -193,6 +193,7 @@ Yes, through:
 
 = 1.3.2 - 2026-xx-xx =
 * Tweak - Remove product block editor compatibility declaration.
+* Tweak - WordPress 7.1 Compatibility.
 
 = 1.3.1 - 2026-07-27 =
 * Tweak - WooCommerce 11.0 Compatibility.


### PR DESCRIPTION
### Description

Declares compatibility with WordPress 7.1.

This is the last plugin in the WordPress 7.1 compatibility wave. The other 19 shipped on 21–22 August; this repo was the only one that never got a PR, so its headers still advertised 7.0.

Compatibility was verified against a live WordPress 7.1 site before bumping the headers rather than declared on faith. Evidence is under Test Instructions.

Closes CUSFEES-30.

### Changes in this PR

- Bumps `Tested up to` from 7.0 to 7.1 and `Requires at least` from 6.9 to 7.0, in both `customs-fees-for-woocommerce.php` and `readme.txt`.
- Adds `* Tweak - WordPress 7.1 Compatibility.` to all three changelog locations (`changelog.txt`, `readme.txt`, `README.md`) per AGENTS.md.
- Updates the AGENTS.md stack table so its stated WordPress support range does not contradict the new headers.

Three points where this differs from the other 19 PRs in the wave, called out so they are not a surprise in the diff:

1. **The changelog line goes in the existing 1.3.2 block rather than a new version entry.** The other PRs opened a new `2026-xx-xx` entry because their previous version had already shipped. Here `Stable tag` is still `1.3.1` while the version constant is already `1.3.2`, so `1.3.2` is the unreleased in-flight release. No manual version bump, per AGENTS.md.
2. **`readme.txt` headers are included.** The reference PRs touched only the plugin file and `changelog.txt`, because those repos do not carry these headers in `readme.txt`. This one does, and CUSFEES-30 asks for it explicitly.
3. **AGENTS.md line 22** previously read `| WordPress | >= 6.9, tested up to 7.0 |`. Happy to drop that hunk if we would rather keep this PR to the three canonical changelog files.

### Test Instructions

Verified on WordPress 7.1 / WooCommerce 11.0.0 / PHP 8.2.

1. Checkout this branch on a site running WordPress 7.1.
2. Activate Customs Fees for WooCommerce. Confirm it activates with no fatal error.
3. Go to **WooCommerce → Settings → Tax → Customs & Import Fees**. Confirm the screen renders: default product origin, FOB/CIF valuation, preset loader, and the rules table.
4. Click **Add New Rule**, set a label and a rate of `10`, leave From/To as `(any)`, and Save. Then click **Save changes** and reload to confirm the rule persists.
5. Add a product to the cart. Confirm a **Customs & Import Fees** line appears and equals 10% of the subtotal.
6. Open the block checkout and confirm the fee line and order total carry through.
7. With Query Monitor active, confirm no PHP errors panel appears on any of the above, and no browser console errors.
8. In `customs-fees-for-woocommerce.php` and `readme.txt`, verify `Tested up to: 7.1` and `Requires at least: 7.0`.

Observed on this branch: activation clean; Query Monitor produced no `php_errors` panel on any screen; "Doing it Wrong" reported no occurrences; no console errors on load or through the rule editor; a 10% rule produced **$3.40** on a **$34.00** subtotal in both the cart and the block checkout, for a **$47.40** total. The block checkout — the most likely place for a WordPress 7.1 React 19 problem to surface — rendered without error.

Not covered: origin/destination matching, HS-code and category rules, CIF valuation, preset import, order emails, and the order admin screen. The test store's products have no Country of Origin data, so origin-matched rules could not be exercised without further setup.

Two pre-existing issues noticed while testing. Neither is introduced here and neither is in scope:

- The rule editor's country list still has no `EU` pseudo-code (`'EU' in cfwc_admin.countries` is `false`). That is CUSFEES-22, which has PR #29 open against it.
- `changelog.txt` dates 1.3.2 as `2026-08-05` while `readme.txt` has the same version as `2026-xx-xx`. That belongs with the documentation inconsistencies in CUSFEES-25.

### Things to check

- [x] Are all texts internationalized? — no user-facing strings changed.
- [x] Has a cache been added? — n/a, metadata only.
- [x] Are the hooks/filters called only when necessary? — n/a, no hooks touched.
- [x] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications? — yes, via Query Monitor on WordPress 7.1. No PHP errors, no console errors.
