### PR TITLE
Pin GitHub Actions to full commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,16 +24,16 @@ jobs:
         run: git config --global url.https://github.com/.insteadOf git://github.com/
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 10
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: '.nvmrc'
 
@@ -44,7 +44,7 @@ jobs:
         run: pnpm build:qit
 
       - name: Upload plugin zip
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ env.PLUGIN_NAME }}
           path: ${{ env.PLUGIN_NAME }}.zip

--- a/.github/workflows/cron_qit.yml
+++ b/.github/workflows/cron_qit.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2
         with:
           status: success
           message: 'Scheduled workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> passed.'
@@ -54,7 +54,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2
         with:
           status: failure
           message: 'Scheduled workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> failed. You can find the results in the artifacts section.'

--- a/.github/workflows/manual_qit.yml
+++ b/.github/workflows/manual_qit.yml
@@ -103,7 +103,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2
         with:
           status: success
           message: 'Test Runner Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> passed.'
@@ -116,7 +116,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2
         with:
           status: cancelled
           message: 'Test Runner Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> cancelled.'
@@ -129,7 +129,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2
         with:
           status: failure
           message: 'Test Runner Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> failed.'

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2
         with:
           status: success
           message: "Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> passed."
@@ -54,7 +54,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2
         with:
           status: cancelled
           message: "Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> cancelled."
@@ -67,7 +67,7 @@ jobs:
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
-      - uses: act10ns/slack@v2
+      - uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2
         with:
           status: failure
           message: "Workflow <{{workflowUrl}}|{{workflow}}> with run ID <{{workflowRunUrl}}|{{runId}}> in PR <{{refUrl}}|{{ref}}> failed."

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -47,15 +47,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Download build
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: customs-fees-for-woocommerce
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2
         with:
           php-version: '8.1'
           tools: composer:v2
@@ -73,7 +73,7 @@ jobs:
         id: run-activation-test
         run: ./vendor/bin/qit run:activation ${{ env.PLUGIN_NAME }} --zip=${{ env.PLUGIN_NAME }}.zip --wait > activation-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ failure() && steps.run-activation-test.conclusion == 'failure' }}
         with:
           header: QIT activation result
@@ -86,7 +86,7 @@ jobs:
         id: run-security-test
         run: ./vendor/bin/qit run:security ${{ env.PLUGIN_NAME }} --zip=${{ env.PLUGIN_NAME }}.zip --wait > security-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ failure() && steps.run-security-test.conclusion == 'failure' }}
         with:
           header: QIT security result
@@ -99,7 +99,7 @@ jobs:
         id: run-malware-test
         run: ./vendor/bin/qit run:malware ${{ env.PLUGIN_NAME }} --zip=${{ env.PLUGIN_NAME }}.zip --wait > malware-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ failure() && steps.run-malware-test.conclusion == 'failure' }}
         with:
           header: QIT malware result
@@ -112,7 +112,7 @@ jobs:
         id: run-api-test
         run: ./vendor/bin/qit run:woo-api ${{ env.PLUGIN_NAME }} --zip=${{ env.PLUGIN_NAME }}.zip --wait > api-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ failure() && steps.run-api-test.conclusion == 'failure' }}
         with:
           header: QIT API result
@@ -125,7 +125,7 @@ jobs:
         id: run-e2e-test
         run: ./vendor/bin/qit run:woo-e2e ${{ env.PLUGIN_NAME }} --zip=${{ env.PLUGIN_NAME }}.zip --wait > e2e-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ failure() && steps.run-e2e-test.conclusion == 'failure' }}
         with:
           header: QIT E2E result
@@ -138,7 +138,7 @@ jobs:
         id: run-phpstan-test
         run: ./vendor/bin/qit run:phpstan ${{ env.PLUGIN_NAME }} --zip=${{ env.PLUGIN_NAME }}.zip --wait > phpstan-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ failure() && steps.run-phpstan-test.conclusion == 'failure' }}
         with:
           header: QIT PHPStan result
@@ -151,7 +151,7 @@ jobs:
         id: run-phpcompat-test
         run: ./vendor/bin/qit run:phpcompatibility ${{ env.PLUGIN_NAME }} --zip=${{ env.PLUGIN_NAME }}.zip --wait > phpcompat-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ failure() && steps.run-phpcompat-test.conclusion == 'failure' }}
         with:
           header: QIT PHPCompat result
@@ -164,7 +164,7 @@ jobs:
         id: run-validation-test
         run: ./vendor/bin/qit run:validation ${{ env.PLUGIN_NAME }} --zip=${{ env.PLUGIN_NAME }}.zip --wait > validation-result.txt
 
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2
         if: ${{ failure() && steps.run-validation-test.conclusion == 'failure' }}
         with:
           header: QIT validation result

--- a/.github/workflows/qit_runner.yml
+++ b/.github/workflows/qit_runner.yml
@@ -96,7 +96,7 @@ jobs:
                   mkdir ${{ github.workspace }}/qit-results
 
             - name: Download the zip
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
               with:
                   name: ${{ inputs.artifact }}
                   path: ${{ github.workspace }}
@@ -280,7 +280,7 @@ jobs:
 
             - name: Upload results
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
               with:
                   name: qit-results
                   path: ${{ github.workspace }}/qit-results/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,18 +14,18 @@ jobs:
     steps:
       # 1. Checkout the repository code
       - name: 👉 Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
 
       # 2. Setup pnpm
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
           version: 10
 
       # 3. Setup Node.js
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version-file: '.nvmrc'
 
@@ -39,7 +39,7 @@ jobs:
 
       # 6. Upload the zipped project as a release asset
       - name: 📤 Upload Release Asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           files: customs-fees-for-woocommerce.zip
         env:

--- a/.github/workflows/update-requires-headers.yml
+++ b/.github/workflows/update-requires-headers.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Fetch Latest WooCommerce Release
         id: fetch_wc_release


### PR DESCRIPTION
### Description

WooCommerce intends to enforce full-length commit SHA pinning for GitHub Actions across the organization. This pins every remote action reference to the commit currently identified by its existing tag or branch, retaining that ref in a comment. Immutable references reduce the risk that a moved or compromised upstream ref can silently change CI code and narrow the supply-chain compromise surface.

### Changes in this PR

- Pin remote GitHub Actions to full 40-character commit SHAs.
- Preserve the original tag or branch next to each pin for maintainability.
- Leave local actions and reusable workflow references unchanged.

### Test Instructions

1. Re-run the action reference scanner in check mode and confirm zero unpinned remote action references remain.
2. Run `git diff --check`.
3. Parse every changed workflow file as YAML.

All three checks pass on this branch. No changelog is needed because this changes workflow configuration only and is not shipped to merchants.

### Things to check

Here are some things we should check every time we create a PR. Depending on the changes made, some things may not apply to the current PR.

This list is intended for the author, but reviewers should also perform these checks.

- [x] Are all texts internationalized? Not applicable; no product text changed.
- [x] Has a cache been added? Not applicable; no runtime code changed.
- [x] Are the hooks/filters called only when necessary? Not applicable; no PHP changed.
- [x] Have the local logs been checked to ensure this PR does not introduce new errors, warnings, or notifications? Not applicable; no runtime code changed.
