### PR TITLE
[CUSFEES-31] Tweak - WooCommerce 11.1 Compatibility.

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** Customs Fees for WooCommerce Changelog ***
 
+2026-xx-xx - version 1.3.4
+* Tweak - WooCommerce 11.1 Compatibility.
+
 2026-08-24 - version 1.3.3
 * Tweak - WordPress 7.1 Compatibility.
 

--- a/customs-fees-for-woocommerce.php
+++ b/customs-fees-for-woocommerce.php
@@ -14,8 +14,8 @@
  * Requires at least: 7.0
  * Tested up to:      7.1
  * Requires PHP:      7.4
- * WC requires at least: 10.8
- * WC tested up to:   11.0
+ * WC requires at least: 10.9
+ * WC tested up to:   11.1
  * Woo: 18734005702334:78cd9350327fbb9496bc3fbfd7335b53
  *
  * @package CustomsFeesForWooCommerce

--- a/readme.txt
+++ b/readme.txt
@@ -5,8 +5,8 @@ Requires at least: 7.0
 Tested up to: 7.1
 Requires PHP: 7.4
 Requires Plugins: woocommerce
-WC requires at least: 10.8
-WC tested up to: 11.0
+WC requires at least: 10.9
+WC tested up to: 11.1
 Stable tag: 1.3.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -190,6 +190,9 @@ Yes, through:
 8. Email with customs fee information
 
 == Changelog ==
+
+= 1.3.4 - 2026-xx-xx =
+* Tweak - WooCommerce 11.1 Compatibility.
 
 = 1.3.3 - 2026-xx-xx =
 * Tweak - WordPress 7.1 Compatibility.


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow [WooCommerce](https://docs.woocommerce.com/document/create-a-plugin/) and [WordPress](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) standards?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Declares compatibility with WooCommerce 11.1 and bumps the minimum required WooCommerce version to 10.9.

Closes #CUSFEES-31 .

### How to test the changes in this Pull Request:

1. Install the plugin alongside WooCommerce 11.1.
2. Verify the plugin activates without errors.
3. Confirm core functionality works correctly with no errors logged.

### Other information:

* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - WooCommerce 11.1 Compatibility.
