### PR TITLE
ci: add job-level timeout-minutes to workflow jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: Build plugin artifact (zip file)
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     outputs:
       plugin_name: ${{ inputs.plugin_name }}
     env:

--- a/.github/workflows/cron_qit.yml
+++ b/.github/workflows/cron_qit.yml
@@ -38,6 +38,7 @@ jobs:
     needs: qit-tests
     name: Handle success
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -51,6 +52,7 @@ jobs:
     needs: qit-tests
     name: Handle failure
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/manual_qit.yml
+++ b/.github/workflows/manual_qit.yml
@@ -100,6 +100,7 @@ jobs:
     needs: qit-tests
     name: Handle success
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -113,6 +114,7 @@ jobs:
     needs: qit-tests
     name: Handle cancellation
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -126,6 +128,7 @@ jobs:
     needs: qit-tests
     name: Handle failure
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/merge_to_main.yml
+++ b/.github/workflows/merge_to_main.yml
@@ -38,6 +38,7 @@ jobs:
     needs: qit-tests
     name: Handle success
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -51,6 +52,7 @@ jobs:
     needs: qit-tests
     name: Handle cancellation
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -64,6 +66,7 @@ jobs:
     needs: qit-tests
     name: Handle failure
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:

--- a/.github/workflows/qit.yml
+++ b/.github/workflows/qit.yml
@@ -40,6 +40,7 @@ jobs:
     needs: build
     name: Run QIT
     runs-on: ubuntu-latest
+    timeout-minutes: 30
 
     env:
       NO_COLOR: 1

--- a/.github/workflows/qit_runner.yml
+++ b/.github/workflows/qit_runner.yml
@@ -75,6 +75,7 @@ jobs:
     qit-tests:
         name: Run QIT Tests
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         steps:
             - name: Install QIT via composer
               shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       # 1. Checkout the repository code

--- a/.github/workflows/update-requires-headers.yml
+++ b/.github/workflows/update-requires-headers.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   update-headers:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Add job timeouts so runs fail fast instead of hanging for up to 6 hours.

| Job | Median (30 d) | Max (30 d) | `timeout-minutes` |
| -- | -- | -- | -- |
| `build.yml` / `build` | 0.33 min | 0.43 min | 5 |
| `qit_runner.yml` / `qit-tests` | 22.07 min | 22.87 min | 30 |
| `release.yml` / `build` | 0.33 min | 0.37 min | 5 |
| `cron_qit.yml` / `handle-success` | 0.07 min | 0.10 min | 5 |
| `cron_qit.yml` / `handle-error` | no successful runs | no successful runs | 5 |
| `manual_qit.yml` / `handle-success` | no runs | no runs | 5 |
| `manual_qit.yml` / `handle-cancelled` | no runs | no runs | 5 |
| `manual_qit.yml` / `handle-error` | no runs | no runs | 5 |
| `merge_to_main.yml` / `handle-success` | no runs | no runs | 5 |
| `merge_to_main.yml` / `handle-cancelled` | no runs | no runs | 5 |
| `merge_to_main.yml` / `handle-error` | no runs | no runs | 5 |
| `qit.yml` / `test` | no successful runs | no successful runs | 30 |
| `update-requires-headers.yml` / `update-headers` | 0.13 min (failed runs) | 0.33 min (failed runs) | 5 |

The seven jobs that call a reusable workflow with `uses:` take no `timeout-minutes`; `build.yml` and `qit_runner.yml` limit them.

Part of TESTOPS-272
